### PR TITLE
GraphQL on localnet

### DIFF
--- a/scripts/common/__globals.sh
+++ b/scripts/common/__globals.sh
@@ -2594,7 +2594,7 @@ start_sui_process() {
     if $SUI_BASE_NET_MOCK; then
       SUI_PROCESS_PID=$SUI_BASE_NET_MOCK_PID
     else
-      nohup env SUI_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1 SUI_PROTOCOL_CONFIG_OVERRIDE_min_checkpoint_interval_ms=1000 RUST_LOG="error" "$SUI_BIN_DIR/sui" start --network.config "$NETWORK_CONFIG" >"$CONFIG_DATA_DIR/sui-process.log" 2>&1 &
+      nohup env SUI_PROTOCOL_CONFIG_OVERRIDE_ENABLE=1 SUI_PROTOCOL_CONFIG_OVERRIDE_min_checkpoint_interval_ms=1000 RUST_LOG="error" "$SUI_BIN_DIR/sui" start --with-indexer --with-graphql --network.config "$NETWORK_CONFIG" >"$CONFIG_DATA_DIR/sui-process.log" 2>&1 &
     fi
     #NEW_PID=$!
 

--- a/scripts/common/sui-indexer-postgres.sh
+++ b/scripts/common/sui-indexer-postgres.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+# --- Configuration Variables ---
+PG_USER="postgres"
+PG_DB="sui_indexer"
+PG_PASSWORD="postgrespw"
+PG_VERSION=$(dpkg-query -W -f='${Version}\n' postgresql | cut -d'.' -f1)
+
+if [[ -z "$PG_VERSION" ]]; then
+    echo "PostgreSQL is not installed or version could not be determined. Proceeding with installation."
+fi
+
+# --- Helper functions ---
+# Function to execute psql commands as the postgres user
+run_psql() {
+    sudo -u postgres psql -c "$1"
+}
+
+# --- 1. Install PostgreSQL (if not already installed) ---
+if ! command -v psql &> /dev/null
+then
+    echo "Installing PostgreSQL..."
+    sudo apt update
+    sudo apt install -y postgresql postgresql-contrib
+    echo "PostgreSQL installation complete."
+else
+    echo "PostgreSQL is already installed."
+fi
+
+# Get the major version of PostgreSQL
+PG_VERSION=$(dpkg-query -W -f='${Version}\n' postgresql | cut -d'.' -f1)
+
+# Ensure the service is running
+echo "Checking PostgreSQL service status..."
+if ! systemctl is-active --quiet postgresql; then
+    echo "PostgreSQL service is not running. Starting it now..."
+    sudo systemctl start postgresql
+    sudo systemctl enable postgresql
+    sleep 5 # Give the service time to start
+else
+    echo "PostgreSQL service is already running."
+fi
+
+# --- 2. Setup user and password ---
+echo "Setting password for user '$PG_USER'..."
+run_psql "ALTER USER $PG_USER WITH ENCRYPTED PASSWORD '$PG_PASSWORD';"
+
+# --- 3. Create database if it doesn't exist ---
+echo "Creating database '$PG_DB' if it doesn't exist..."
+if ! run_psql "\\l" | grep -q "$PG_DB"; then
+    run_psql "CREATE DATABASE $PG_DB;"
+    echo "Database '$PG_DB' created successfully."
+else
+    echo "Database '$PG_DB' already exists. Skipping creation."
+fi
+
+# --- 4. Configure authentication for local connections ---
+# The default `peer` authentication method on a fresh install prevents
+# password-based connections. We will modify `pg_hba.conf`.
+echo "Configuring pg_hba.conf for password authentication..."
+
+# Path to the config file depends on the version
+HBA_CONF="/etc/postgresql/$PG_VERSION/main/pg_hba.conf"
+if [[ -f "$HBA_CONF" ]]; then
+    # Replace `peer` with `md5` for local connections
+    sudo sed -i "s/local\s\+all\s\+all\s\+peer/local   all             all                     md5/" "$HBA_CONF"
+else
+    echo "Warning: pg_hba.conf not found at $HBA_CONF. Manual configuration may be required."
+fi
+
+# --- 5. Restart PostgreSQL to apply changes ---
+echo "Restarting PostgreSQL service to apply configuration changes..."
+sudo systemctl restart postgresql
+echo "PostgreSQL setup complete. You can now connect using the provided db_url."


### PR DESCRIPTION
- added --with-indexer & --with-graphql to the `start` command 
- added a postgres install script & start which uses the default values:
```
      --pg-port <PG_PORT>
          Port for the Indexer Postgres DB. Default port is 5432
          
          [default: 5432]

      --pg-host <PG_HOST>
          Hostname for the Indexer Postgres DB. Default host is localhost
          
          [default: localhost]

      --pg-db-name <PG_DB_NAME>
          DB name for the Indexer Postgres DB. Default DB name is sui_indexer
          
          [default: sui_indexer]

      --pg-user <PG_USER>
          DB username for the Indexer Postgres DB. Default username is postgres
          
          [default: postgres]

      --pg-password <PG_PASSWORD>
          DB password for the Indexer Postgres DB. Default password is postgrespw
          
          [default: postgrespw]
```