### PR TITLE
proxy_grpc: never route to non-selectable upstreams

### DIFF
--- a/.github/actions/diffs/action.yml
+++ b/.github/actions/diffs/action.yml
@@ -23,6 +23,9 @@ outputs:
   isVSCodeExtension:
     description: True when changes to Suibase VSCode extension
     value: "${{ steps.diff.outputs.isVSCodeExtension }}"
+  isTypeScriptHelper:
+    description: True when changes to the TypeScript helper
+    value: "${{ steps.diff.outputs.isTypeScriptHelper }}"
 
 runs:
   using: composite
@@ -61,3 +64,7 @@ runs:
             - '.github/workflows/trig-sui-binaries.yml'
           isVSCodeExtension::
             - 'typescript/vscode-extension/**'
+          isTypeScriptHelper:
+            - 'typescript/helper/**'
+            - 'scripts/tests/040_typescript_tests/**'
+            - '.github/workflows/typescript-tests.yml'

--- a/.github/workflows/main-nightly-tests.yml
+++ b/.github/workflows/main-nightly-tests.yml
@@ -91,6 +91,43 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           ln -s "$GITHUB_WORKSPACE" "$HOME/suibase"
 
+      - name: Verify suibase-daemon precompiled matches main's source version
+        # On main, rust/suibase/Cargo.toml is authoritative for the daemon
+        # version end users receive. If chainmovers/sui-binaries has not yet
+        # published a precompiled at that version, end users are protected
+        # by the sb_app_install gate (they stay on their existing binary
+        # with a warning), but this nightly is supposed to validate the
+        # released pair. A mismatch means the dev → main merge happened
+        # before sui-binaries finished publishing — fail fast with a clear
+        # message instead of letting the rest of the suite fail diffusely.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          # Install suibase symlinks + trigger daemon precompiled download.
+          # start-daemon calls start_suibase_daemon_as_needed → sb_app_install.
+          "$HOME/suibase/install"
+          "$HOME/suibase/scripts/dev/start-daemon"
+
+          src_version=$(grep "^version" "$GITHUB_WORKSPACE/rust/suibase/Cargo.toml" \
+            | sed -e 's/version[[:space:]]*=[[:space:]]*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)".*/\1/')
+          bin_version=$("$HOME/suibase/workdirs/common/bin/suibase-daemon" --version 2>/dev/null \
+            | awk '{print $2}')
+
+          echo "main source version:      $src_version"
+          echo "installed binary version: $bin_version"
+
+          if [ -z "$src_version" ] || [ -z "$bin_version" ]; then
+            echo "::error::Could not read versions (src='$src_version', bin='$bin_version')"
+            exit 1
+          fi
+
+          if [ "$src_version" != "$bin_version" ]; then
+            echo "::error::main's rust/suibase/Cargo.toml is at suibase-daemon v$src_version but the precompiled available on chainmovers/sui-binaries is v$bin_version. The release-coordination handshake is incomplete — main was likely bumped before sui-binaries published the matching release. Check https://github.com/chainmovers/sui-binaries/releases and re-run this workflow once the new tag is available."
+            exit 1
+          fi
+          echo "Version match confirmed: $src_version"
+
       - name: Exhaustive Tests of Suibase main branch (the only release branch).
         env:
           CI_BRANCH: ${{ matrix.ci_branch }}

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -46,6 +46,37 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           ln -s "$GITHUB_WORKSPACE" "$HOME/suibase"
 
+      - name: Verify suibase-daemon precompiled matches main's source version
+        # See main-nightly-tests.yml for full rationale. Same fast-fail
+        # check here: a main push that arrives before sui-binaries has
+        # published the matching precompiled is a release-coordination
+        # bug, not something later tests should slowly discover.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          "$HOME/suibase/install"
+          "$HOME/suibase/scripts/dev/start-daemon"
+
+          src_version=$(grep "^version" "$GITHUB_WORKSPACE/rust/suibase/Cargo.toml" \
+            | sed -e 's/version[[:space:]]*=[[:space:]]*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)".*/\1/')
+          bin_version=$("$HOME/suibase/workdirs/common/bin/suibase-daemon" --version 2>/dev/null \
+            | awk '{print $2}')
+
+          echo "main source version:      $src_version"
+          echo "installed binary version: $bin_version"
+
+          if [ -z "$src_version" ] || [ -z "$bin_version" ]; then
+            echo "::error::Could not read versions (src='$src_version', bin='$bin_version')"
+            exit 1
+          fi
+
+          if [ "$src_version" != "$bin_version" ]; then
+            echo "::error::main's rust/suibase/Cargo.toml is at suibase-daemon v$src_version but the precompiled available on chainmovers/sui-binaries is v$bin_version. The release-coordination handshake is incomplete — main was likely pushed before sui-binaries published the matching release. Check https://github.com/chainmovers/sui-binaries/releases and re-run this workflow once the new tag is available."
+            exit 1
+          fi
+          echo "Version match confirmed: $src_version"
+
       - name: Only sanity tests the release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -60,22 +60,31 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: "false"
+          target: ${{ runner.os == 'Linux' && 'x86_64-unknown-linux-musl' || '' }}
 
-      - name: Rust caching (demo-app + helper for publish)
+      - name: Rust caching (suibase-daemon + demo-app)
         uses: Swatinem/rust-cache@v2
         env:
           RUST_ADD_CACHE_KEY_COMPONENT: ${{ matrix.os }}-typescript-helper
         with:
           workspaces: |
+            rust/suibase
             rust/demo-app
-            rust/helper
           cache-provider: github
           cache-all-crates: false
+
+      - name: Install Rust musl target (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # Match suibase-daemon-tests.yml: musl is needed for the daemon build.
+          rust_channel=$(grep '^channel' "$GITHUB_WORKSPACE/rust/suibase/rust-toolchain.toml" | sed 's/channel = "\(.*\)"/\1/')
+          echo "Installing Rust $rust_channel toolchain with musl target"
+          rustup toolchain install "$rust_channel" --target x86_64-unknown-linux-musl --profile minimal
 
       - name: Sui Prerequesites (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install curl cmake gcc libssl-dev pkg-config libclang-dev libpq-dev build-essential
+          sudo apt-get install curl cmake gcc libssl-dev pkg-config libclang-dev libpq-dev build-essential musl musl-tools musl-dev
 
       - name: Prepare environment
         run: |
@@ -86,6 +95,22 @@ jobs:
       - name: Install suibase (creates ~/.local/bin symlinks)
         run: |
           "$HOME/suibase/install"
+
+      - name: Build suibase-daemon from source (non-main branches)
+        # The installer keeps the latest released precompiled binary except
+        # on the main branch, where source > released triggers an upgrade.
+        # That gating is correct for end users but the wrong default for
+        # CI on dev branches: the released binary lags the dev source, so
+        # any new daemon feature exercised by the test (e.g. proxying
+        # changes a newer sui client depends on) is missing in CI.
+        #
+        # On non-main branches we force a source build so CI validates the
+        # branch's own code. On main we let the installer keep the released
+        # binary so this workflow doubles as a smoke test that downloading
+        # the published precompiled artifact still works.
+        if: github.ref != 'refs/heads/main'
+        run: |
+          "$HOME/suibase/scripts/dev/update-daemon"
 
       - name: Run TypeScript helper tests
         env:

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -83,6 +83,10 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           ln -s "$GITHUB_WORKSPACE" "$HOME/suibase"
 
+      - name: Install suibase (creates ~/.local/bin symlinks)
+        run: |
+          "$HOME/suibase/install"
+
       - name: Run TypeScript helper tests
         env:
           CI_WORKDIR: localnet

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -1,0 +1,92 @@
+name: TypeScript Tests
+# Tests for the suibase TypeScript helper (typescript/helper/).
+#
+# Mirrors rust-tests.yml at a smaller scale: this is opt-in for projects that
+# install the helper from a relative path, so we only test against localnet
+# (the workdir against which the 'demo' package is published).
+
+on:
+  push:
+    branches: ["dev"]
+
+  workflow_dispatch:
+
+jobs:
+  diff:
+    runs-on: [ubuntu-latest]
+    outputs:
+      isChanged: ${{ steps.diff.outputs.isScript == 'true' || steps.diff.outputs.isRust == 'true' || steps.diff.outputs.isTypeScriptHelper == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect Changes
+        uses: "./.github/actions/diffs"
+        id: diff
+
+  test:
+    name: Test ${{ matrix.os }}
+    needs: diff
+    if: ${{ (needs.diff.outputs.isChanged == 'true') || (github.event_name == 'workflow_dispatch') }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        # The TS helper only has a localnet integration story (demo package),
+        # so unlike rust-tests we do not need a per-workdir matrix.
+
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: false
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Rust Toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: "false"
+
+      - name: Rust caching (demo-app + helper for publish)
+        uses: Swatinem/rust-cache@v2
+        env:
+          RUST_ADD_CACHE_KEY_COMPONENT: ${{ matrix.os }}-typescript-helper
+        with:
+          workspaces: |
+            rust/demo-app
+            rust/helper
+          cache-provider: github
+          cache-all-crates: false
+
+      - name: Sui Prerequesites (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install curl cmake gcc libssl-dev pkg-config libclang-dev libpq-dev build-essential
+
+      - name: Prepare environment
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          ln -s "$GITHUB_WORKSPACE" "$HOME/suibase"
+
+      - name: Run TypeScript helper tests
+        env:
+          CI_WORKDIR: localnet
+          CI_BRANCH: testnet
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash "$HOME/suibase/scripts/tests/040_typescript_tests/npm_test_suibase_helper.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,12 @@ output.bpl
 # Move build output (specific to suibase repo)
 **/move/build
 
+# Sui CLI artifacts that may be emitted in package or workspace dirs.
+# The intentional Move.lock under move/ is tracked separately.
+rust/demo-app/Move.lock
+rust/demo-app/Published.toml
+rust/demo-app/build/
+
 # logs
 wallet.log.*
 sui.log.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ Only notable changes are documented here. See GitHub commits for all changes.
 
 Suibase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.11] TBD
+## [0.1.11] 2026-05-22  
+### Added
+
+- gRPC (HTTP/2) proxying in suibase-daemon. JSON-RPC is deprecated.
+
+### Fixed
+
+- `add_private_keys` in suibase.yaml now works with recent sui releases (>= 1.7x)
+  that require `SUI_CONFIG_DIR` to be set even for keystore-only operations.
 
 
 ## [0.1.10] 2025-09-04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to Suibase
+
+## Releasing a new `suibase-daemon` version
+
+A daemon release is a coordinated change across three repos: this one
+(`suibase`), [`chainmovers/sui-binaries`](https://github.com/chainmovers/sui-binaries)
+(which publishes precompiled binaries for end users), and the user's local
+suibase checkout. Get the order wrong and end users land between versions.
+
+### Version sources
+
+Three places track "what version is `suibase-daemon`":
+
+| Where | Authority |
+| --- | --- |
+| `rust/suibase/Cargo.toml` (this repo) | What the **branch under test** describes |
+| `workdirs/common/bin/suibase-daemon-version.yaml` | What is **actually running** on a user's machine |
+| Latest release tag on `chainmovers/sui-binaries` | What is **available to download** |
+
+The user-facing invariant the install/upgrade logic enforces is:
+
+```
+installed_binary_version <= local_source_version
+```
+
+That is, a user's binary can lag their scripts (safe — old binary speaks an
+older protocol), but it never gets ahead of their scripts. The
+`sb_app_install` gate in `scripts/common/__apps.sh` refuses to download a
+precompiled newer than the user's source.
+
+### Merge sequence for a version bump
+
+The dev → main flow is the brittle part. Follow this order:
+
+1. **Bump `rust/suibase/Cargo.toml` on `dev`** (e.g. `0.3.0` → `0.4.0`) and
+   open a PR against `dev`. CI on `dev` builds the daemon from source.
+2. **Wait for `sui-binaries` to publish the precompiled.**
+   `.github/workflows/suibase-daemon-tests.yml` has a `trig` job that pushes
+   `Cargo.toml` into `chainmovers/sui-binaries:triggers/suibase-daemon/`,
+   which kicks off the binary build on that side. Confirm via the releases
+   page of `chainmovers/sui-binaries` that a release tagged with the new
+   version has appeared.
+3. **Only then merge `dev` → `main`.**
+   Once main is bumped, every existing user worldwide running
+   `~/suibase/update` (or any command that triggers
+   `start_suibase_daemon_as_needed`) pulls the new precompiled. If
+   sui-binaries hasn't published yet, the local-source-version gate keeps
+   them on the old binary and prints a warning — which is correct but
+   noisy. Best to skip the noisy window entirely.
+
+### What happens if I get it wrong
+
+- **Merge to main before sui-binaries publishes**: end users on main will
+  pull the bumped scripts via `~/suibase/update` but the install logic
+  will refuse to download a binary newer than their source. They stay on
+  the old binary with a warning. They're not broken, but they don't get
+  the new daemon until sui-binaries catches up.
+- **Bump version mid-dev without intending to release**: harmless. The
+  `sui-binaries` side will see the trigger but the published tag is
+  CI-suffixed (`_ci`), which the user-facing install filter excludes.
+  End users see nothing.
+
+### CI conventions
+
+- Workflows in `.github/workflows/` trigger on `push: branches: [dev]`.
+  Each workflow that needs the daemon's source-built version (e.g.
+  `typescript-tests.yml`) explicitly runs `scripts/dev/update-daemon` on
+  non-main runs so the binary under test matches the branch's source.
+- On main, those workflows let `~/suibase/install` download the
+  precompiled instead, which doubles as a smoke test of the download path.

--- a/move/@suibase/log/Move.toml
+++ b/move/@suibase/log/Move.toml
@@ -1,11 +1,15 @@
 [package]
-name = "Log"
+name = "log"
 version = "0.0.1"
-edition = "2024.alpha"
+edition = "2024.beta"
+
+# Modern Move 2024 derives the named-address from the package name
+# at compile time; modules in this package therefore reference
+# `log::<module>` matching `name` above. No [addresses] table is
+# permitted alongside [environments] (mutually exclusive — having
+# both flips the manifest parser into legacy mode and ignores
+# environments).
+[environments]
+localnet = "756b253e"
 
 [dependencies]
-Sui = { local = "../../../../suibase/workdirs/active/sui-repo/crates/sui-framework/packages/sui-framework" }
-#Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "devnet" }
-
-[addresses]
-log =  "0x0"

--- a/rust/demo-app/move/Move.toml
+++ b/rust/demo-app/move/Move.toml
@@ -3,10 +3,15 @@ name = "demo"
 version = "0.0.1"
 edition = "2024.beta"
 
-[dependencies]
-Sui = { local = "../../../../suibase/workdirs/active/sui-repo/crates/sui-framework/packages/sui-framework" }
-#Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "devnet" }
-Log = { local = "../../../../suibase/move/@suibase/log" }
+# Localnet env entry. The publish flow may activate the `localnet_proxy`
+# env; sui-package-alt falls back to chain-id matching when the active
+# env name is not present here, so this single entry handles both the
+# direct `localnet` env and the proxy-routed `localnet_proxy` env by
+# virtue of sharing the same chain ID (localnet genesis is deterministic
+# in suibase). `testnet` and `mainnet` are sui system envs and cannot
+# be defined here — sui-package-alt provides them implicitly.
+[environments]
+localnet = "756b253e"
 
-[addresses]
-demo =  "0x0"
+[dependencies]
+log = { local = "../../../../suibase/move/@suibase/log" }

--- a/rust/suibase/.cargo/config.toml
+++ b/rust/suibase/.cargo/config.toml
@@ -1,7 +1,12 @@
 [target.'cfg(all())']
-rustflags = ["--cfg", "uuid_unstable"]
+# `-D warnings` matches CI behavior: `actions-rust-lang/setup-rust-toolchain@v1`
+# sets RUSTFLAGS=-D warnings by default, so a warning that compiles fine
+# locally fails the macOS/Linux CI build. Setting it here makes local
+# builds (incl. `scripts/dev/update-daemon`) fail with the same strictness,
+# so dead-code / unused-import warnings get caught during development.
+rustflags = ["--cfg", "uuid_unstable", "-D", "warnings"]
 # Use the following if enabling tokio-console for instrumentation.
-# rustflags = ["--cfg", "uuid_unstable", "--cfg", "tokio_unstable" ]
+# rustflags = ["--cfg", "uuid_unstable", "--cfg", "tokio_unstable", "-D", "warnings"]
 
 [alias]
 test-poi = "test -p poi-server --features integration-tests"

--- a/rust/suibase/Cargo.lock
+++ b/rust/suibase/Cargo.lock
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -3339,7 +3339,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "suibase-daemon"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/rust/suibase/Cargo.toml
+++ b/rust/suibase/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["crates/dtp-daemon",
 #       Changing build field does not trig auto-update (only new installation would
 #       get the updated build).
 #
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [workspace.dependencies]

--- a/rust/suibase/crates/suibase-daemon/src/proxy_server.rs
+++ b/rust/suibase/crates/suibase-daemon/src/proxy_server.rs
@@ -39,6 +39,7 @@ use crate::proxy_grpc::{
     forward_to_upstream, grpc_no_upstream_response, is_grpc_request, BufferedGrpcRequest,
     ForwardOutcome, GrpcProxyClient,
 };
+use crate::shared_types::TargetServer;
 
 // An application target the localhost:port
 //
@@ -554,9 +555,6 @@ impl ProxyServer {
                     } else {
                         let mut best: Vec<(u8, String)> = Vec::new();
                         input_port.get_best_target_servers(&mut best, &handler_start);
-                        let mut seen_idx: std::collections::HashSet<u8> =
-                            std::collections::HashSet::new();
-                        let mut ordered: Vec<(u8, String)> = Vec::new();
                         let grpc_capable = |idx: u8| -> bool {
                             input_port
                                 .target_servers
@@ -564,17 +562,11 @@ impl ProxyServer {
                                 .map(|ts| ts.stats.is_grpc_capable())
                                 .unwrap_or(true)
                         };
-                        for (idx, url) in best {
-                            if grpc_capable(idx) && seen_idx.insert(idx) {
-                                ordered.push((idx, url));
-                            }
-                        }
-                        for (idx, ts) in input_port.target_servers.iter() {
-                            if grpc_capable(idx) && seen_idx.insert(idx) {
-                                ordered.push((idx, ts.rpc()));
-                            }
-                        }
-                        ordered
+                        select_grpc_upstreams(
+                            best,
+                            &input_port.target_servers,
+                            grpc_capable,
+                        )
                     }
                 }
                 _ => Vec::new(),
@@ -1017,5 +1009,147 @@ struct JsonRpcErrorDataObject {
 impl JsonRpcErrorDataObject {
     fn new(origin: String, retry: u8) -> Self {
         Self { origin, retry }
+    }
+}
+
+/// Build the prioritized gRPC upstream list for one request.
+///
+/// `best` is the list returned by `InputPort::get_best_target_servers`,
+/// already filtered to selectable + healthy servers. Those come first,
+/// in `best`'s order, skipped only if they fail the gRPC-capability
+/// check. Then any other **selectable**, gRPC-capable target follows
+/// as fallback.
+///
+/// Non-selectable servers are NEVER picked — mirrors JSON-RPC's
+/// `update_selection_vectors` (which skips `!is_selectable`) so the
+/// two protocols agree about what `selectable: false` means: never
+/// route to me, not even as last resort. Without this, a daemon-
+/// internal mock server or a `selectable: false` operator-parked
+/// upstream would silently receive production gRPC traffic if it
+/// happened to be the only gRPC-capable target left.
+fn select_grpc_upstreams(
+    best: Vec<(u8, String)>,
+    target_servers: &ManagedVec<TargetServer>,
+    is_grpc_capable: impl Fn(u8) -> bool,
+) -> Vec<(u8, String)> {
+    let mut seen_idx: std::collections::HashSet<u8> = std::collections::HashSet::new();
+    let mut ordered: Vec<(u8, String)> = Vec::new();
+    for (idx, url) in best {
+        if is_grpc_capable(idx) && seen_idx.insert(idx) {
+            ordered.push((idx, url));
+        }
+    }
+    for (idx, ts) in target_servers.iter() {
+        if ts.is_selectable() && is_grpc_capable(idx) && seen_idx.insert(idx) {
+            ordered.push((idx, ts.rpc()));
+        }
+    }
+    ordered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::shared_types::Link;
+
+    fn make_ts(alias: &str, selectable: bool) -> TargetServer {
+        let mut link = Link::new(alias.to_string(), format!("http://{}:9000", alias));
+        link.selectable = selectable;
+        TargetServer::new(link)
+    }
+
+    fn mv_of(items: Vec<TargetServer>) -> ManagedVec<TargetServer> {
+        let mut mv = ManagedVec::new();
+        for ts in items {
+            mv.push(ts);
+        }
+        mv
+    }
+
+    #[test]
+    fn non_selectable_server_is_never_picked_even_as_fallback() {
+        // Mirrors the operator config the regression was found in: a
+        // single `selectable: false` upstream and no selectable peers.
+        // JSON-RPC returns NO_SERVER_AVAILABLE in this case; gRPC must
+        // do the same.
+        let mv = mv_of(vec![make_ts("localnet", /* selectable */ false)]);
+        let result = select_grpc_upstreams(Vec::new(), &mv, |_| true);
+        assert!(
+            result.is_empty(),
+            "selectable:false server must NOT be picked; got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn selectable_server_picked_when_not_in_best() {
+        // `best` may be empty if the network monitor hasn't scored
+        // servers yet. The fallback loop still needs to find any
+        // selectable + gRPC-capable target.
+        let mv = mv_of(vec![make_ts("upstream", true)]);
+        let result = select_grpc_upstreams(Vec::new(), &mv, |_| true);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, 0u8);
+    }
+
+    #[test]
+    fn best_servers_take_priority_in_their_order() {
+        // `best` is already sorted by the network monitor. Preserve
+        // its order; only add fallbacks AFTER all best entries.
+        let mv = mv_of(vec![
+            make_ts("a", true), // idx 0
+            make_ts("b", true), // idx 1
+            make_ts("c", true), // idx 2
+        ]);
+        let best = vec![
+            (2u8, "http://c:9000".to_string()),
+            (0u8, "http://a:9000".to_string()),
+        ];
+        let result = select_grpc_upstreams(best, &mv, |_| true);
+        // c, a, then b (the leftover selectable fallback).
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].0, 2);
+        assert_eq!(result[1].0, 0);
+        assert_eq!(result[2].0, 1);
+    }
+
+    #[test]
+    fn non_grpc_capable_servers_are_skipped_in_both_loops() {
+        // Mark idx 1 as not gRPC-capable; it must not appear via
+        // either `best` (loop 1) or fallback (loop 2).
+        let mv = mv_of(vec![
+            make_ts("a", true), // idx 0
+            make_ts("b", true), // idx 1 — declared not gRPC-capable below
+        ]);
+        let best = vec![(1u8, "http://b:9000".to_string())];
+        let result = select_grpc_upstreams(best, &mv, |idx| idx != 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, 0);
+    }
+
+    #[test]
+    fn duplicates_between_best_and_fallback_are_deduped() {
+        // A selectable server in `best` must not appear twice when
+        // the fallback loop iterates the same target_servers.
+        let mv = mv_of(vec![make_ts("a", true)]);
+        let best = vec![(0u8, "http://a:9000".to_string())];
+        let result = select_grpc_upstreams(best, &mv, |_| true);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn mixed_selectable_non_selectable_only_returns_selectable() {
+        // The user's local dev config that triggered the
+        // investigation: mocks marked selectable=true, the real
+        // backend marked selectable=false. After this fix, traffic
+        // never silently falls back to the non-selectable backend.
+        let mv = mv_of(vec![
+            make_ts("mock-0", true),     // idx 0
+            make_ts("mock-1", true),     // idx 1
+            make_ts("localnet", false),  // idx 2  — must be excluded
+        ]);
+        let result = select_grpc_upstreams(Vec::new(), &mv, |_| true);
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|(idx, _)| *idx == 0 || *idx == 1));
     }
 }

--- a/rust/suibase/crates/suibase-daemon/src/shared_types/server_stats.rs
+++ b/rust/suibase/crates/suibase-daemon/src/shared_types/server_stats.rs
@@ -21,6 +21,9 @@ pub const REQUEST_FAILED_RESP_BUILDER: u8 = 4;
 pub const REQUEST_FAILED_NETWORK_DOWN: u8 = 5; // Not implemented yet.
 pub const REQUEST_FAILED_BAD_REQUEST_HTTP: u8 = 6; // Got HTTP Bad Request (400), Bad Method (405), etc.
 pub const REQUEST_FAILED_CONFIG_DISABLED: u8 = 7;
+// Reserved enum slot (used by a commented-out check in proxy_server.rs). Kept
+// to preserve the wire-protocol indexing of `req_failure_reasons`.
+#[allow(dead_code)]
 pub const REQUEST_FAILED_NOT_STARTED: u8 = 8;
 // Upstream answered, but it doesn't speak gRPC (e.g. JSON-RPC-only public
 // gateway returning HTML/JSON). Used by the gRPC forwarder to permanently

--- a/rust/suibase/crates/suibase-daemon/tests/common/mock_test_utils.rs
+++ b/rust/suibase/crates/suibase-daemon/tests/common/mock_test_utils.rs
@@ -1041,7 +1041,7 @@ impl MockServerTestHarness {
                 .await?;
 
             // Check debug output for selection information
-            if let Some(debug_info) = &stats.debug {
+            if let Some(_debug_info) = &stats.debug {
                 // The debug info should contain information about selection_vectors
                 // which determines the load balancing subset
 

--- a/rust/suibase/crates/suibase-daemon/tests/common/mod.rs
+++ b/rust/suibase/crates/suibase-daemon/tests/common/mod.rs
@@ -1,4 +1,12 @@
-// Common test utilities for suibase-daemon integration tests
+// Common test utilities for suibase-daemon integration tests.
+//
+// Each integration test compiles `mod common` independently and only uses
+// a subset of the helpers, so the rest look "dead" to that test binary.
+// Suppress dead-code warnings module-wide — this is the canonical Rust
+// pattern for shared test utilities with `-D warnings` enabled at the
+// workspace level (see rust/suibase/.cargo/config.toml).
+#![allow(dead_code)]
+#![allow(unused_imports)]
 
 pub mod mock_test_utils;
 

--- a/rust/suibase/crates/suibase-daemon/tests/proxy_performance_benchmark_test.rs
+++ b/rust/suibase/crates/suibase-daemon/tests/proxy_performance_benchmark_test.rs
@@ -122,7 +122,7 @@ async fn test_proxy_server_performance_benchmark() -> Result<()> {
 
             let total_duration = start_time.elapsed();
             let total_successful = successful_requests.load(Ordering::Relaxed);
-            let total_failed = failed_requests.load(Ordering::Relaxed);
+            let _total_failed = failed_requests.load(Ordering::Relaxed);
             let avg_latency_ms = if total_successful > 0 {
                 total_latency_ms.load(Ordering::Relaxed) as f64 / total_successful as f64
             } else {

--- a/scripts/common/__apps.sh
+++ b/scripts/common/__apps.sh
@@ -1060,22 +1060,26 @@ sb_app_set_local_vars() {
         fi
       fi
 
-      # Check if the source code is newer than the local binary (this can happen after "~/suibase/update").
+      # Source version ahead of installed binary — typical right after
+      # "~/suibase/update" pulls a new release.
       #
-      # Upgrade only if major.minor in source code is higher (ignore patch and build).
+      # On main: trigger a re-install pass so sb_app_install picks up a
+      # newer precompiled from sui-binaries (if published). The pass is a
+      # no-op when the precompiled hasn't caught up yet (see local_src
+      # gate inside sb_app_install).
       #
-      # Only the main branch is considered for upgrade (because the precompiled binary for _LOCAL_SRC_VERSION need
-      # to exists).
+      # On non-main: source typically leads released precompiled, by
+      # design. Stay on the released binary; developers who want the
+      # source build can run ~/suibase/scripts/dev/update-daemon.
       if [ "$_ALL_INSTALLED" = "true" ] && [ -n "$_LOCAL_SRC_VERSION" ] && [ -n "$_LOCAL_BIN_version" ] && [ "$_SRC_TYPE" = "suibase" ]; then
-        # Get the branch name of the local repo.
         local _LOCAL_BRANCH
         _LOCAL_BRANCH=$(git -C "$SUIBASE_DIR" rev-parse --abbrev-ref HEAD)
         if version_less_than "$_LOCAL_BIN_version" "$_LOCAL_SRC_VERSION"; then
           if [ "$_LOCAL_BRANCH" = "main" ]; then
             _ALL_INSTALLED="false"
-            echo "Upgrading $_ASSETS_NAME from $_LOCAL_BIN_version to $_LOCAL_SRC_VERSION"
+            echo "$_ASSETS_NAME source is at $_LOCAL_SRC_VERSION but installed binary is $_LOCAL_BIN_version; checking sui-binaries for a matching release"
           else
-            echo "Not upgrading $_ASSETS_NAME from $_LOCAL_BIN_version to $_LOCAL_SRC_VERSION (not on main branch: $_LOCAL_BRANCH)"
+            echo "$_ASSETS_NAME source ($_LOCAL_SRC_VERSION) is ahead of installed binary ($_LOCAL_BIN_version); staying on $_LOCAL_BIN_version (run ~/suibase/scripts/dev/update-daemon to build from source)"
           fi
         fi
       fi
@@ -1298,14 +1302,41 @@ sb_app_install() {
     else
       get_app_var "$self" "is_installed"
       local _IS_INSTALLED=$APP_VAR
+      get_app_var "$self" "local_bin_version"
+      local _LOCAL_BIN_LATEST_VERSION=$APP_VAR
+      get_app_var "$self" "PRECOMP_REMOTE_VERSION"
+      local _PRECOMP_REMOTE_VERSION=$APP_VAR
+      get_app_var "$self" "local_src_version"
+      local _LOCAL_SRC_VERSION=$APP_VAR
+
+      # Cap the precompiled download at the user's local source version. This
+      # protects users on stale checkouts from auto-upgrading to a daemon
+      # binary that may be incompatible with their (older) scripts. The user
+      # gets a precise instruction (run ~/suibase/update) instead of a silent
+      # leapfrog.
+      #
+      # The gate is only meaningful when we know both versions; otherwise it
+      # is a no-op. For Mysten Labs assets (sui, walrus, ...) local_src_version
+      # is empty, so the historical behavior is preserved.
+      if [ -n "$_LOCAL_SRC_VERSION" ] && [ -n "$_PRECOMP_REMOTE_VERSION" ]; then
+        if version_less_than "$_LOCAL_SRC_VERSION" "$_PRECOMP_REMOTE_VERSION"; then
+          if [ "$_IS_INSTALLED" = "true" ]; then
+            warn_user "Skipping $_ASSETS_NAME upgrade to $_PRECOMP_REMOTE_VERSION: your suibase scripts are at $_LOCAL_SRC_VERSION. Keeping installed binary $_LOCAL_BIN_LATEST_VERSION. Run '~/suibase/update' to refresh scripts and binary together."
+            return
+          else
+            # No binary at all on a stale checkout: warn and let the install
+            # proceed against the remote (so the user is not left without a
+            # daemon). This is the lesser-evil branch — should be rare in
+            # practice, since fresh clones bring matching scripts.
+            warn_user "$_ASSETS_NAME $_PRECOMP_REMOTE_VERSION is newer than your suibase scripts ($_LOCAL_SRC_VERSION). Installing anyway because no local binary exists; run '~/suibase/update' soon to keep scripts and binary aligned."
+          fi
+        fi
+      fi
+
       local _DO_INSTALL="false"
       if [ "$_IS_INSTALLED" != "true" ]; then
         _DO_INSTALL="true"
       else
-        get_app_var "$self" "local_bin_version"
-        local _LOCAL_BIN_LATEST_VERSION=$APP_VAR
-        get_app_var "$self" "PRECOMP_REMOTE_VERSION"
-        local _PRECOMP_REMOTE_VERSION=$APP_VAR
         if [ -n "$_LOCAL_BIN_LATEST_VERSION" ] && [ -n "$_PRECOMP_REMOTE_VERSION" ]; then
           if version_less_than "$_LOCAL_BIN_LATEST_VERSION" "$_PRECOMP_REMOTE_VERSION"; then
             _DO_INSTALL="true"

--- a/scripts/common/__globals.sh
+++ b/scripts/common/__globals.sh
@@ -11,7 +11,7 @@ export USER_CWD=$(pwd -P)
 # Format is: "major.minor.patch-build"
 #
 # The build hash is best-effort appended later.
-export SUIBASE_VERSION="0.1.10"
+export SUIBASE_VERSION="0.1.11"
 
 # Suibase does not work with version below these.
 export MIN_SUI_VERSION="sui 0.27.0"

--- a/scripts/tests/010_unit_test_common/test_mutex.sh
+++ b/scripts/tests/010_unit_test_common/test_mutex.sh
@@ -227,28 +227,45 @@ test_active_lock_protection() {
     ' &
     
     local bg_pid=$!
-    sleep 0.5  # Let background process acquire lock
-    
+
+    # Poll for the lock to appear (up to 10s). A fixed `sleep 0.5` was used
+    # before but macOS GitHub-hosted runners are slow to spawn bash + source
+    # __globals.sh + acquire the mutex, causing CI flakes.
+    local _waited=0
+    while [ $_waited -lt 100 ] && [ ! -f "/tmp/.suibase/cli-mainnet.lock/holder.info" ]; do
+        sleep 0.1
+        _waited=$((_waited + 1))
+    done
+
     # Verify lock exists with background process PID
     if [ ! -f "/tmp/.suibase/cli-mainnet.lock/holder.info" ]; then
         kill $bg_pid 2>/dev/null || true
         wait $bg_pid 2>/dev/null || true
         fail "Background process didn't create lock"
     fi
-    
+
     local holder_pid
     holder_pid=$(grep "^pid=" "/tmp/.suibase/cli-mainnet.lock/holder.info" | cut -d= -f2)
-    
+
     # Test that stale detection correctly identifies this as NOT stale
     if _is_mutex_stale "/tmp/.suibase/cli-mainnet.lock"; then
         kill $bg_pid 2>/dev/null || true
         wait $bg_pid 2>/dev/null || true
         fail "Active lock incorrectly detected as stale"
     fi
-    
+
     # Wait for background process to finish
     wait $bg_pid
-    
+
+    # Poll for cleanup (up to 10s). The lock removal runs via the trap in
+    # cli_mutex_release; on slow runners the wait can return before the
+    # filesystem op completes (especially with macOS APFS).
+    _waited=0
+    while [ $_waited -lt 100 ] && [ -d "/tmp/.suibase/cli-mainnet.lock" ]; do
+        sleep 0.1
+        _waited=$((_waited + 1))
+    done
+
     # Now the lock should be gone
     if [ -d "/tmp/.suibase/cli-mainnet.lock" ]; then
         fail "Background process didn't clean up lock"

--- a/scripts/tests/040_typescript_tests/__test_common.sh
+++ b/scripts/tests/040_typescript_tests/__test_common.sh
@@ -57,18 +57,27 @@ localnet set-active
 # Helper integration tests require the 'demo' package to be published.
 if [ ! -d "$HOME/suibase/workdirs/localnet/published-data/demo" ]; then
   cd "$HOME/suibase/rust/demo-app" || fail "'cd $HOME/suibase/rust/demo-app' failed"
-  localnet publish
+  localnet publish || fail "'localnet publish' failed for demo"
+fi
+# Confirm demo really got published (localnet publish can return 0 even on
+# protocol errors). The integration test needs the 'most-recent' symlink.
+if [ ! -L "$HOME/suibase/workdirs/localnet/published-data/demo/most-recent" ]; then
+  fail "'localnet publish' did not create demo/most-recent symlink"
 fi
 
 do_tests() {
   update_HOST_vars
 
+  # Run npm commands in a subshell, but capture its exit code so we
+  # do not silently swallow failures. `fail` inside a (...) only exits
+  # the subshell.
   (
-    cd "$NPM_DIR" || fail "'cd $NPM_DIR' failed"
-    npm install --no-audit --no-fund || fail "'npm install' failed in $NPM_DIR"
-    npm run typecheck || fail "'npm run typecheck' failed in $NPM_DIR"
-    npm test || fail "'npm test' failed in $NPM_DIR"
-  )
+    set -e
+    cd "$NPM_DIR"
+    npm install --no-audit --no-fund
+    npm run typecheck
+    npm test
+  ) || fail "'npm test' failed in $NPM_DIR"
 
   assert_workdir_ok "$WORKDIR"
 }

--- a/scripts/tests/040_typescript_tests/__test_common.sh
+++ b/scripts/tests/040_typescript_tests/__test_common.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Common code for TypeScript helper test scripts.
+#
+# The first parameter is the directory where the npm-based tests will be run.
+
+SUIBASE_DIR="$HOME/suibase"
+
+# shellcheck source=SCRIPTDIR/../__scripts-lib-before-globals.sh
+SCRIPT_COMMON_CALLER="$(readlink -f "$0")"
+WORKDIR="localnet"
+NPM_DIR="$1"
+shift
+
+# shellcheck source=SCRIPTDIR/../__scripts-lib-before-globals.sh
+source "$SUIBASE_DIR/scripts/tests/__scripts-lib-before-globals.sh"
+
+# shellcheck source=SCRIPTDIR/../../common/__globals.sh
+source "$SUIBASE_DIR/scripts/common/__globals.sh" "$SCRIPT_COMMON_CALLER" "$WORKDIR"
+trap cleanup EXIT
+
+# shellcheck source=SCRIPTDIR/../__scripts-lib-after-globals.sh
+source "$SUIBASE_DIR/scripts/tests/__scripts-lib-after-globals.sh"
+
+if [ "$FAST_OPTION" = "true" ]; then
+  echo "Skipping $NPM_DIR (fast option)"
+  return 2
+fi
+
+# Helper tests must run against localnet (demo package is published there).
+if [ "$WORKDIR" != "localnet" ]; then
+  echo "Skipping $NPM_DIR (not localnet)"
+  return 2
+fi
+
+if [ "$RELEASE_TESTS_OPTION" = "true" ]; then
+  echo "Skipping $NPM_DIR (not done on release tests)"
+  return 2
+fi
+
+# Skip if Node.js is not available. The TypeScript helper is opt-in:
+# suibase end-users do not need Node.js installed.
+if ! command -v node >/dev/null 2>&1; then
+  echo "Skipping $NPM_DIR (node not installed)"
+  return 2
+fi
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Skipping $NPM_DIR (npm not installed)"
+  return 2
+fi
+
+# Require Node >= 20.
+_node_major=$(node -e 'process.stdout.write(String(process.versions.node.split(".")[0]))' 2>/dev/null)
+if [ -z "$_node_major" ] || [ "$_node_major" -lt 20 ]; then
+  echo "Skipping $NPM_DIR (node v$_node_major < 20)"
+  return 2
+fi
+
+localnet start
+localnet set-active
+
+# Helper integration tests require the 'demo' package to be published.
+if [ ! -d "$HOME/suibase/workdirs/localnet/published-data/demo" ]; then
+  cd "$HOME/suibase/rust/demo-app" || fail "'cd $HOME/suibase/rust/demo-app' failed"
+  localnet publish
+fi
+
+do_tests() {
+  update_HOST_vars
+
+  (
+    cd "$NPM_DIR" || fail "'cd $NPM_DIR' failed"
+    npm install --no-audit --no-fund || fail "'npm install' failed in $NPM_DIR"
+    npm run typecheck || fail "'npm run typecheck' failed in $NPM_DIR"
+    npm test || fail "'npm test' failed in $NPM_DIR"
+  )
+
+  assert_workdir_ok "$WORKDIR"
+}
+
+do_tests

--- a/scripts/tests/040_typescript_tests/__test_common.sh
+++ b/scripts/tests/040_typescript_tests/__test_common.sh
@@ -33,11 +33,6 @@ if [ "$WORKDIR" != "localnet" ]; then
   return 2
 fi
 
-if [ "$RELEASE_TESTS_OPTION" = "true" ]; then
-  echo "Skipping $NPM_DIR (not done on release tests)"
-  return 2
-fi
-
 # Skip if Node.js is not available. The TypeScript helper is opt-in:
 # suibase end-users do not need Node.js installed.
 if ! command -v node >/dev/null 2>&1; then

--- a/scripts/tests/040_typescript_tests/npm_test_suibase_helper.sh
+++ b/scripts/tests/040_typescript_tests/npm_test_suibase_helper.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# shellcheck source=SCRIPTDIR/__test_common.sh
+source "$HOME/suibase/scripts/tests/040_typescript_tests/__test_common.sh" "$HOME/suibase/typescript/helper"

--- a/scripts/tests/__scripts-lib-before-globals.sh
+++ b/scripts/tests/__scripts-lib-before-globals.sh
@@ -19,6 +19,7 @@ export MAIN_BRANCH_OPTION=false
 export SCRIPTS_TESTS_OPTION=false
 export SUIBASE_DAEMON_TESTS_OPTION=false
 export RUST_TESTS_OPTION=false
+export TYPESCRIPT_TESTS_OPTION=false
 export RELEASE_TESTS_OPTION=false
 export MAIN_MERGE_CHECK_OPTION=false
 
@@ -102,6 +103,7 @@ init_tests_set_vars() {
   SCRIPTS_TESTS_OPTION=$1
   SUIBASE_DAEMON_TESTS_OPTION=$1
   RUST_TESTS_OPTION=$1
+  TYPESCRIPT_TESTS_OPTION=$1
   RELEASE_TESTS_OPTION=$1
 }
 
@@ -123,6 +125,7 @@ test_setup_on_sourcing() {
     --scripts-tests) SCRIPTS_TESTS_OPTION=true; _ONE_TEST_SET=true ;;
     --suibase-daemon-tests) SUIBASE_DAEMON_TESTS_OPTION=true; _ONE_TEST_SET=true ;;
     --rust-tests) RUST_TESTS_OPTION=true; _ONE_TEST_SET=true ;;
+    --typescript-tests) TYPESCRIPT_TESTS_OPTION=true; _ONE_TEST_SET=true ;;
     --release-tests) RELEASE_TESTS_OPTION=true; _ONE_TEST_SET=true ;;
 
     --main-merge-check) MAIN_MERGE_CHECK_OPTION=true ;;

--- a/scripts/tests/run-all.sh
+++ b/scripts/tests/run-all.sh
@@ -83,6 +83,7 @@ main() {
     --scripts-tests|\
     --suibase-daemon-tests|\
     --rust-tests|\
+    --typescript-tests|\
     --release-tests|\
     --main-merge-check|\
     --dev-push-check|\

--- a/typescript/helper/.gitignore
+++ b/typescript/helper/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store
+coverage/

--- a/typescript/helper/README.md
+++ b/typescript/helper/README.md
@@ -1,0 +1,57 @@
+# Suibase Helper for TypeScript
+
+API to Suibase, intended for development of Sui tool/test automation (Playwright, Vitest, etc.)
+and TypeScript-based backends.
+
+Functionally equivalent to the [Rust helper](../../rust/helper/).
+
+## Install
+
+This package is not published to npm. Reference it via a local path so the helper and your
+Suibase installation are guaranteed to match versions.
+
+```jsonc
+// In your project's package.json
+{
+  "devDependencies": {
+    "suibase": "file:../../suibase/typescript/helper"
+  }
+}
+```
+
+Adjust the relative path depending on where your `package.json` is located relative to
+`~/suibase`. The helper has **zero runtime dependencies**.
+
+## Usage
+
+```ts
+import { Helper } from "suibase";
+
+const sbh = new Helper();
+if (sbh.isInstalled()) {
+  sbh.selectWorkdir("localnet");
+  console.log("active address is", sbh.clientAddress("active"));
+  console.log("demo package id is", sbh.packageId("demo"));
+}
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `isInstalled()` | Returns `true` if `~/suibase` is found. |
+| `selectWorkdir(name)` | Pick one of `active`, `localnet`, `devnet`, `testnet`, `mainnet`, … |
+| `workdir()` | Name of the currently selected workdir (resolves `active`). |
+| `keystorePathname()` | Absolute path to `sui.keystore`. |
+| `packageId(name)` | Object ID of the last successfully published Move package. |
+| `publishedNewObjects(type)` | Object IDs of objects created when the package was published. `type` format: `package::module::type`. |
+| `clientAddress(name)` | Sui address by name (e.g. `active`, `sb-1-ed25519`, …). |
+| `rpcUrl()` | JSON-RPC URL for the selected workdir. |
+| `wsUrl()` | WebSocket URL for the selected workdir. |
+
+All methods are synchronous. Failures throw `SuibaseError` with a `code` field.
+
+## Self-contained
+
+This helper is **not** part of the Suibase installation. End-users of Suibase do not need
+Node.js installed. Only consumers of this helper need Node, when they build their own project.

--- a/typescript/helper/package.json
+++ b/typescript/helper/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "suibase",
+  "version": "0.0.1",
+  "description": "Helper library to assist development, testing and deployment of Sui Move apps with Suibase.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ChainMovers/suibase.git",
+    "directory": "typescript/helper"
+  },
+  "homepage": "https://suibase.io",
+  "keywords": ["sui", "move", "suibase"],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "src", "README.md", "LICENSE"],
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc -p .",
+    "clean": "rm -rf dist",
+    "test": "node --import tsx --test tests/*.test.ts",
+    "test:unit": "node --import tsx --test tests/unit/*.test.ts",
+    "test:integration": "node --import tsx --test tests/integration/*.test.ts",
+    "typecheck": "tsc -p . --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/typescript/helper/package.json
+++ b/typescript/helper/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "tsc -p .",
     "clean": "rm -rf dist",
-    "test": "node --import tsx --test tests/*.test.ts",
+    "test": "node --import tsx --test tests/unit/*.test.ts tests/integration/*.test.ts",
     "test:unit": "node --import tsx --test tests/unit/*.test.ts",
     "test:integration": "node --import tsx --test tests/integration/*.test.ts",
     "typecheck": "tsc -p . --noEmit"

--- a/typescript/helper/src/error.ts
+++ b/typescript/helper/src/error.ts
@@ -1,0 +1,58 @@
+export type SuibaseErrorCode =
+  // API caller errors
+  | "NotInstalled"
+  | "WorkdirNotSelected"
+  | "WorkdirAccessError"
+  | "WorkdirNotExists"
+  | "SuibaseKeystoreNotExists"
+  | "PublishedDataNotFound"
+  | "MissingLinkDefinition"
+  | "MissingAtLeastOneLinkDefinition"
+  | "MissingLinkField"
+  | "ConfigAccessError"
+  | "ConfigReadError"
+  | "ConfigActiveAddressParseError"
+  // Bad parameter errors
+  | "WorkdirNameEmpty"
+  | "PackageNameEmpty"
+  | "AddressNameEmpty"
+  | "ObjectTypeMissingField"
+  | "ObjectTypeInvalidFormat"
+  | "AddressNameNotFound"
+  // Suibase filesystem related
+  | "WorkdirStateNameAccessFailed"
+  | "WorkdirStateDNSAccessFailed"
+  | "WorkdirStateNameNotSet"
+  | "PackageIdJsonInvalidFormat"
+  | "PackageIdInvalidHex"
+  | "PublishedNewObjectReadError"
+  | "PublishedNewObjectParseError"
+  | "WorkdirInitializationIncomplete"
+  | "WorkdirStateDNSReadError"
+  | "WorkdirStateDNSParseError"
+  | "PublishedDataAccessError"
+  | "PublishedDataAccessErrorInvalidSymlink"
+  | "PublishedDataAccessErrorSymlinkNotFound"
+  | "PublishedNewObjectAccessError"
+  | "WorkdirStateLinkReadError"
+  // Internal
+  | "WorkdirNameNotSet"
+  | "WorkdirPathNotSet"
+  | "FileNameEmpty"
+  | "StateNameEmpty";
+
+export class SuibaseError extends Error {
+  readonly code: SuibaseErrorCode;
+  readonly context: Record<string, string>;
+
+  constructor(
+    code: SuibaseErrorCode,
+    message: string,
+    context: Record<string, string> = {},
+  ) {
+    super(`suibase: ${message}`);
+    this.name = "SuibaseError";
+    this.code = code;
+    this.context = context;
+  }
+}

--- a/typescript/helper/src/index.ts
+++ b/typescript/helper/src/index.ts
@@ -1,0 +1,98 @@
+// suibase
+//
+// API to suibase intended for development of Sui tool/test automation
+// (Playwright, Vitest, ...) and TypeScript-based backends.
+//
+// See https://suibase.io for more info.
+
+import { SuibaseError } from "./error.js";
+import { SuibaseRoot } from "./suibaseRoot.js";
+import { SuibaseWorkdir } from "./suibaseWorkdir.js";
+
+export { SuibaseError } from "./error.js";
+export type { SuibaseErrorCode } from "./error.js";
+
+export interface HelperOptions {
+  /**
+   * Override the suibase installation directory. Defaults to `~/suibase`.
+   * Mostly useful for testing.
+   */
+  rootPath?: string;
+}
+
+/**
+ * A lightweight API to suibase. Multiple instances can be created within the same app.
+ *
+ * Usage:
+ *   1. Call `isInstalled()` to confirm suibase is available.
+ *   2. Call `selectWorkdir()` to pick a workdir (`active`, `localnet`, …).
+ *   3. Call any of the other methods. Most relate to the selected workdir.
+ */
+export class Helper {
+  private readonly root: SuibaseRoot;
+  private workdir_?: SuibaseWorkdir;
+
+  constructor(options: HelperOptions = {}) {
+    this.root = new SuibaseRoot(options.rootPath);
+  }
+
+  isInstalled(): boolean {
+    return this.root.isInstalled();
+  }
+
+  selectWorkdir(workdirName: string): void {
+    const wd = new SuibaseWorkdir();
+    wd.initFromExisting(this.root, workdirName);
+    this.workdir_ = wd;
+  }
+
+  workdir(): string {
+    return this.requireWorkdir().getName();
+  }
+
+  keystorePathname(): string {
+    return this.requireWorkdir().keystorePathname(this.root);
+  }
+
+  packageObjectId(packageName: string): string {
+    return this.requireWorkdir().packageObjectId(this.root, packageName);
+  }
+
+  packageId(packageName: string): string {
+    return this.packageObjectId(packageName);
+  }
+
+  publishedNewObjectIds(objectType: string): string[] {
+    return this.requireWorkdir().publishedNewObjectIds(this.root, objectType);
+  }
+
+  publishedNewObjects(objectType: string): string[] {
+    return this.publishedNewObjectIds(objectType);
+  }
+
+  clientSuiAddress(addressName: string): string {
+    return this.requireWorkdir().clientSuiAddress(this.root, addressName);
+  }
+
+  clientAddress(addressName: string): string {
+    return this.clientSuiAddress(addressName);
+  }
+
+  rpcUrl(): string {
+    return this.requireWorkdir().rpcUrl(this.root);
+  }
+
+  wsUrl(): string {
+    return this.requireWorkdir().wsUrl(this.root);
+  }
+
+  private requireWorkdir(): SuibaseWorkdir {
+    if (!this.workdir_) {
+      throw new SuibaseError(
+        "WorkdirNotSelected",
+        "Workdir not selected. Successful call to `selectWorkdir` needed",
+      );
+    }
+    return this.workdir_;
+  }
+}

--- a/typescript/helper/src/objectId.ts
+++ b/typescript/helper/src/objectId.ts
@@ -1,0 +1,32 @@
+// Sui ObjectID / SuiAddress are 32-byte hex strings prefixed with "0x".
+// In their canonical form they are 66 characters total. Shorter values
+// are accepted as input and left-padded with zeros — mirroring Rust's
+// `ObjectID::from_hex_literal` behavior.
+
+import { SuibaseError, type SuibaseErrorCode } from "./error.js";
+
+const HEX_RE = /^[0-9a-fA-F]*$/;
+
+export function normalizeObjectId(
+  input: string,
+  invalidCode: SuibaseErrorCode,
+  context: Record<string, string> = {},
+): string {
+  if (!input.startsWith("0x") && !input.startsWith("0X")) {
+    throw new SuibaseError(
+      invalidCode,
+      `Invalid object id hexadecimal '${input}'.`,
+      { id: input, ...context },
+    );
+  }
+  const hex = input.slice(2);
+  if (hex.length === 0 || hex.length > 64 || !HEX_RE.test(hex)) {
+    throw new SuibaseError(
+      invalidCode,
+      `Invalid object id hexadecimal '${input}'.`,
+      { id: input, ...context },
+    );
+  }
+  const padded = hex.padStart(64, "0").toLowerCase();
+  return `0x${padded}`;
+}

--- a/typescript/helper/src/suibaseRoot.ts
+++ b/typescript/helper/src/suibaseRoot.ts
@@ -1,0 +1,27 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export class SuibaseRoot {
+  private installed = false;
+  readonly suibasePath: string;
+  readonly workdirsPath: string;
+
+  constructor(rootPath?: string) {
+    this.suibasePath = rootPath ?? join(homedir(), "suibase");
+    this.workdirsPath = join(this.suibasePath, "workdirs");
+    this.refreshState();
+  }
+
+  refreshState(): void {
+    const baseOk = this.suibasePath.length > 0 && existsSync(this.suibasePath);
+    const wdOk =
+      this.workdirsPath.length > 0 && existsSync(this.workdirsPath);
+    this.installed = baseOk && wdOk;
+  }
+
+  isInstalled(): boolean {
+    this.refreshState();
+    return this.installed;
+  }
+}

--- a/typescript/helper/src/suibaseWorkdir.ts
+++ b/typescript/helper/src/suibaseWorkdir.ts
@@ -1,0 +1,552 @@
+import {
+  existsSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+
+import { SuibaseError } from "./error.js";
+import { normalizeObjectId } from "./objectId.js";
+import type { SuibaseRoot } from "./suibaseRoot.js";
+import { readTopLevelString } from "./yamlMini.js";
+
+export class SuibaseWorkdir {
+  private workdirName?: string;
+  private workdirPath?: string;
+
+  initFromExisting(root: SuibaseRoot, workdirName: string): void {
+    if (!root.isInstalled()) {
+      throw new SuibaseError(
+        "NotInstalled",
+        "Not installed. Need to run ~/suibase/install",
+      );
+    }
+    if (workdirName.length === 0) {
+      throw new SuibaseError(
+        "WorkdirNameEmpty",
+        "Invalid workdir name (empty string)",
+      );
+    }
+
+    const initialPath = join(root.workdirsPath, workdirName);
+    let resolved: string;
+    try {
+      resolved = realpathSync(initialPath);
+    } catch {
+      throw new SuibaseError(
+        "WorkdirAccessError",
+        "Path could not be accessed. Check suibase is selecting a valid active workdir",
+        { path: initialPath },
+      );
+    }
+    if (!existsSync(resolved)) {
+      throw new SuibaseError(
+        "WorkdirNotExists",
+        "Workdir does not exist. Check suibase is selecting a valid active workdir",
+        { path: resolved },
+      );
+    }
+
+    // Read .state/name to get the canonical workdir name (handles "active").
+    const namePath = join(resolved, ".state", "name");
+    let nameContent: string;
+    try {
+      nameContent = readFileSync(namePath, "utf8").trim();
+    } catch {
+      throw new SuibaseError(
+        "WorkdirAccessError",
+        "Active workdir read of .state/name failed. Try to 'update' the workdir",
+        { path: namePath },
+      );
+    }
+    if (nameContent.length === 0) {
+      throw new SuibaseError(
+        "WorkdirStateNameNotSet",
+        "Active workdir .state/name not set. Try to 'update' the workdir",
+      );
+    }
+
+    this.workdirName = nameContent;
+    this.workdirPath = resolved;
+  }
+
+  getName(): string {
+    if (this.workdirName === undefined) {
+      throw new SuibaseError(
+        "WorkdirNameNotSet",
+        "Workdir name not set. Internal error. Contact developer",
+      );
+    }
+    return this.workdirName;
+  }
+
+  keystorePathname(root: SuibaseRoot): string {
+    this.assertReady(root);
+    const path = join(this.workdirPath!, "config", "sui.keystore");
+    if (!existsSync(path)) {
+      throw new SuibaseError(
+        "SuibaseKeystoreNotExists",
+        `Not finding keystore '${path}'. Run the sui client to create it?`,
+        { path },
+      );
+    }
+    return path;
+  }
+
+  packageObjectId(root: SuibaseRoot, packageName: string): string {
+    const pathname = this.pathnamePublishedFile(
+      root,
+      packageName,
+      "package-id",
+      "json",
+    );
+    let raw: string;
+    try {
+      raw = readFileSync(pathname, "utf8");
+    } catch (io_error) {
+      throw new SuibaseError(
+        "PublishedDataAccessError",
+        `[code:1] Could not open published data '${pathname}'. Was the package '${packageName}' published with success?`,
+        { package_name: packageName, path: pathname, io_error: String(io_error) },
+      );
+    }
+    raw = raw.trim();
+    if (!raw.startsWith('["') || !raw.endsWith('"]')) {
+      throw new SuibaseError(
+        "PackageIdJsonInvalidFormat",
+        "Invalid package-id.json format",
+        { path: pathname },
+      );
+    }
+    const idHex = raw.slice(2, raw.length - 2);
+    return normalizeObjectId(idHex, "PackageIdInvalidHex", { path: pathname });
+  }
+
+  publishedNewObjectIds(root: SuibaseRoot, objectType: string): string[] {
+    // Validate the parameter format: "package::module::type", no whitespace-only fields.
+    const parts = objectType.split("::");
+    const names: string[] = [];
+    for (const found of parts) {
+      const trimmed = found.trim();
+      if (trimmed.length === 0) {
+        throw new SuibaseError(
+          "ObjectTypeMissingField",
+          "Invalid object_type parameter with missing field",
+          { object_type: objectType },
+        );
+      }
+      names.push(trimmed);
+    }
+    if (names.length !== 3) {
+      throw new SuibaseError(
+        "ObjectTypeInvalidFormat",
+        "Invalid object_type parameter",
+        { object_type: objectType },
+      );
+    }
+
+    const pathname = this.pathnamePublishedFile(
+      root,
+      names[0]!,
+      "created-objects",
+      "json",
+    );
+
+    let text: string;
+    try {
+      text = readFileSync(pathname, "utf8");
+    } catch {
+      throw new SuibaseError(
+        "PublishedNewObjectAccessError",
+        `Could not open published new objects file '${pathname}'. Was the package published with success?`,
+        { path: pathname },
+      );
+    }
+
+    let top: unknown;
+    try {
+      top = JSON.parse(text);
+    } catch {
+      throw new SuibaseError(
+        "PublishedNewObjectReadError",
+        `Could not read published new objects file '${pathname}'`,
+        { path: pathname },
+      );
+    }
+
+    const objects: string[] = [];
+    if (Array.isArray(top)) {
+      for (const created of top) {
+        if (created && typeof created === "object") {
+          const obj = created as Record<string, unknown>;
+          const typeStr = typeof obj.type === "string" ? obj.type : undefined;
+          if (!typeStr) continue;
+          const sub = typeStr.split("::");
+          // TODO: check package id (sub[0]) once available.
+          if (
+            sub.length === 3 &&
+            sub[1] === names[1] &&
+            sub[2] === names[2]
+          ) {
+            const idStr =
+              typeof obj.objectId === "string" ? obj.objectId : undefined;
+            if (!idStr) continue;
+            try {
+              objects.push(
+                normalizeObjectId(idStr, "PublishedNewObjectParseError", {
+                  path: pathname,
+                }),
+              );
+            } catch (e) {
+              if (
+                e instanceof SuibaseError &&
+                e.code === "PublishedNewObjectParseError"
+              ) {
+                throw e;
+              }
+              throw new SuibaseError(
+                "PublishedNewObjectParseError",
+                `Could not parse published new objects id '${idStr}' from file '${pathname}'`,
+                { path: pathname, id: idStr },
+              );
+            }
+          }
+        }
+      }
+    }
+    return objects;
+  }
+
+  clientSuiAddress(root: SuibaseRoot, addressName: string): string {
+    if (addressName.length === 0) {
+      throw new SuibaseError(
+        "AddressNameEmpty",
+        "Invalid address name (empty string)",
+      );
+    }
+    if (addressName === "active") {
+      return this.getClientActiveAddress(root);
+    }
+
+    const pathname = this.pathnameState(root, "dns");
+    let text: string;
+    try {
+      text = readFileSync(pathname, "utf8");
+    } catch {
+      throw new SuibaseError(
+        "WorkdirStateDNSAccessFailed",
+        `Could not open DNS (client address) file '${pathname}'. Try to 'update' the workdir`,
+        { path: pathname },
+      );
+    }
+    let top: unknown;
+    try {
+      top = JSON.parse(text);
+    } catch {
+      throw new SuibaseError(
+        "WorkdirStateDNSReadError",
+        `Could not read dns file '${pathname}'`,
+        { path: pathname },
+      );
+    }
+    if (top && typeof top === "object") {
+      const known = (top as Record<string, unknown>).known;
+      if (known && typeof known === "object") {
+        const item = (known as Record<string, unknown>)[addressName];
+        if (item && typeof item === "object") {
+          const addr = (item as Record<string, unknown>).address;
+          if (typeof addr === "string") {
+            return normalizeObjectId(addr, "WorkdirStateDNSParseError", {
+              path: pathname,
+              address: addr,
+            });
+          }
+        }
+      }
+    }
+    throw new SuibaseError(
+      "AddressNameNotFound",
+      `Not finding address name '${addressName}'`,
+      { address_name: addressName },
+    );
+  }
+
+  rpcUrl(root: SuibaseRoot): string {
+    return this.urlFromState(root, "rpc");
+  }
+
+  wsUrl(root: SuibaseRoot): string {
+    return this.urlFromState(root, "ws");
+  }
+
+  // ============ private ============
+
+  private assertReady(root: SuibaseRoot): void {
+    if (!root.isInstalled()) {
+      throw new SuibaseError(
+        "NotInstalled",
+        "Not installed. Need to run ~/suibase/install",
+      );
+    }
+    if (this.workdirName === undefined) {
+      throw new SuibaseError(
+        "WorkdirNameNotSet",
+        "Workdir name not set. Internal error. Contact developer",
+      );
+    }
+    if (this.workdirPath === undefined) {
+      throw new SuibaseError(
+        "WorkdirPathNotSet",
+        "Workdir path not set. Internal error. Contact developer",
+      );
+    }
+  }
+
+  private pathnamePublishedFile(
+    root: SuibaseRoot,
+    packageName: string,
+    fileName: string,
+    extension: string,
+  ): string {
+    if (!root.isInstalled()) {
+      throw new SuibaseError(
+        "NotInstalled",
+        "Not installed. Need to run ~/suibase/install",
+      );
+    }
+    if (packageName.length === 0) {
+      throw new SuibaseError(
+        "PackageNameEmpty",
+        "Invalid package name (empty string)",
+      );
+    }
+    if (fileName.length === 0) {
+      throw new SuibaseError(
+        "FileNameEmpty",
+        "Invalid file name (empty string)",
+      );
+    }
+    if (this.workdirName === undefined) {
+      throw new SuibaseError(
+        "WorkdirNameNotSet",
+        "Workdir name not set. Internal error. Contact developer",
+      );
+    }
+    if (this.workdirPath === undefined) {
+      throw new SuibaseError(
+        "WorkdirPathNotSet",
+        "Workdir path not set. Internal error. Contact developer",
+      );
+    }
+
+    const publishedRoot = join(
+      this.workdirPath,
+      "published-data",
+      packageName,
+    );
+    const mostRecent = join(publishedRoot, "most-recent");
+
+    let symlinkTarget: string;
+    try {
+      symlinkTarget = readlinkSync(mostRecent);
+    } catch {
+      throw new SuibaseError(
+        "PublishedDataAccessErrorSymlinkNotFound",
+        `[code:3] Could not open published data '${mostRecent}'. Was the package '${packageName}' published with success?`,
+        { package_name: packageName, path: mostRecent },
+      );
+    }
+
+    let resolved: string;
+    try {
+      resolved = realpathSync(mostRecent);
+    } catch {
+      throw new SuibaseError(
+        "PublishedDataAccessErrorInvalidSymlink",
+        `[code:2] Could not open published data '${mostRecent}'. Symlink value is '${symlinkTarget}'. Was the package '${packageName}' published with success?`,
+        {
+          package_name: packageName,
+          path: mostRecent,
+          symlink_target: symlinkTarget,
+        },
+      );
+    }
+
+    if (!existsSync(resolved)) {
+      throw new SuibaseError(
+        "PublishedDataNotFound",
+        `No published data found for package '${packageName}'.`,
+        {
+          package_name: packageName,
+          workdir: this.workdirName,
+          path: resolved,
+        },
+      );
+    }
+
+    return join(resolved, `${fileName}.${extension}`);
+  }
+
+  private pathnameState(root: SuibaseRoot, stateName: string): string {
+    if (!root.isInstalled()) {
+      throw new SuibaseError(
+        "NotInstalled",
+        "Not installed. Need to run ~/suibase/install",
+      );
+    }
+    if (stateName.length === 0) {
+      throw new SuibaseError(
+        "StateNameEmpty",
+        "Invalid state name (empty string)",
+      );
+    }
+    if (this.workdirName === undefined) {
+      throw new SuibaseError(
+        "WorkdirNameNotSet",
+        "Workdir name not set. Internal error. Contact developer",
+      );
+    }
+    if (this.workdirPath === undefined) {
+      throw new SuibaseError(
+        "WorkdirPathNotSet",
+        "Workdir path not set. Internal error. Contact developer",
+      );
+    }
+    const stateDir = join(this.workdirPath, ".state");
+    if (!existsSync(stateDir)) {
+      throw new SuibaseError(
+        "WorkdirInitializationIncomplete",
+        `Workdir not fully initialized. Do '${this.workdirName} start' or '${this.workdirName} update'`,
+        { workdir: this.workdirName },
+      );
+    }
+    return join(stateDir, stateName);
+  }
+
+  private urlFromState(root: SuibaseRoot, urlFieldName: string): string {
+    const pathname = this.pathnameState(root, "links");
+    const workdirName = this.workdirName!;
+    let text: string;
+    try {
+      text = readFileSync(pathname, "utf8");
+    } catch {
+      throw new SuibaseError(
+        "WorkdirInitializationIncomplete",
+        `Workdir not fully initialized. Do '${workdirName} start' or '${workdirName} update'`,
+        { workdir: workdirName },
+      );
+    }
+    let top: Record<string, unknown>;
+    try {
+      top = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      throw new SuibaseError(
+        "WorkdirStateLinkReadError",
+        `Could not read link file '${pathname}'`,
+        { path: pathname },
+      );
+    }
+
+    let linkId = 0;
+    const selection = top.selection;
+    if (selection && typeof selection === "object") {
+      const primary = (selection as Record<string, unknown>).primary;
+      if (typeof primary === "number" && Number.isInteger(primary)) {
+        linkId = primary;
+      }
+    }
+
+    const links = top.links;
+    if (linkId === 0) {
+      if (Array.isArray(links)) {
+        if (links.length === 0) {
+          throw new SuibaseError(
+            "MissingLinkDefinition",
+            "Missing link definition. Check suibase.yaml links section.",
+          );
+        }
+        const first = links[0];
+        if (first && typeof first === "object") {
+          const val = (first as Record<string, unknown>)[urlFieldName];
+          if (typeof val === "string") return val;
+        }
+      }
+      throw new SuibaseError(
+        "MissingLinkField",
+        `Missing '${urlFieldName}' link field. May be a problem with the suibase.yaml link section (1).`,
+        { url_field: urlFieldName },
+      );
+    }
+
+    if (Array.isArray(links)) {
+      if (links.length === 0) {
+        throw new SuibaseError(
+          "MissingAtLeastOneLinkDefinition",
+          "Missing at least one link definition. Check suibase.yaml links section.",
+        );
+      }
+      for (const link of links) {
+        if (link && typeof link === "object") {
+          const lid = (link as Record<string, unknown>).id;
+          if (typeof lid === "number" && lid === linkId) {
+            const val = (link as Record<string, unknown>)[urlFieldName];
+            if (typeof val === "string") return val;
+          }
+        }
+      }
+    }
+    throw new SuibaseError(
+      "MissingLinkField",
+      `Missing '${urlFieldName}' link field. May be a problem with the suibase.yaml link section (1).`,
+      { url_field: urlFieldName },
+    );
+  }
+
+  private getClientActiveAddress(root: SuibaseRoot): string {
+    this.assertReady(root);
+    const workdirName = this.workdirName!;
+    const initialPath = join(this.workdirPath!, "config", "client.yaml");
+    let resolved: string;
+    try {
+      resolved = realpathSync(initialPath);
+    } catch {
+      throw new SuibaseError(
+        "ConfigAccessError",
+        `Missing config.yaml. Did you do '${workdirName} start'?`,
+        { workdir: workdirName },
+      );
+    }
+    try {
+      statSync(resolved);
+    } catch {
+      throw new SuibaseError(
+        "ConfigAccessError",
+        `Missing config.yaml. Did you do '${workdirName} start'?`,
+        { workdir: workdirName },
+      );
+    }
+    let text: string;
+    try {
+      text = readFileSync(resolved, "utf8");
+    } catch {
+      throw new SuibaseError(
+        "ConfigReadError",
+        `Access problem with config.yaml. Did you do '${workdirName} start' or run the sui client once?`,
+        { workdir: workdirName },
+      );
+    }
+    const active = readTopLevelString(text, "active_address");
+    if (!active) {
+      throw new SuibaseError(
+        "ConfigActiveAddressParseError",
+        "Unknown active address. Did you run the sui client at least once?",
+        { address: "<missing>" },
+      );
+    }
+    return normalizeObjectId(active, "ConfigActiveAddressParseError", {
+      address: active,
+    });
+  }
+}

--- a/typescript/helper/src/yamlMini.ts
+++ b/typescript/helper/src/yamlMini.ts
@@ -1,0 +1,33 @@
+// Minimal YAML reader for the specific fields Suibase needs to read.
+// We do NOT implement a general YAML parser — only a top-level
+// `key: value` lookup with optional double-quoted strings.
+//
+// This is sufficient for ~/.../config/client.yaml, where the only field
+// the helper cares about is `active_address`.
+
+export function readTopLevelString(
+  yamlText: string,
+  key: string,
+): string | undefined {
+  const re = new RegExp(`^\\s*${escapeRegExp(key)}\\s*:\\s*(.+?)\\s*$`, "m");
+  const match = yamlText.match(re);
+  if (!match || match[1] === undefined) return undefined;
+  let raw = match[1].trim();
+  // Strip an inline `# comment` if there is one (outside quotes).
+  if (!raw.startsWith('"') && !raw.startsWith("'")) {
+    const hashIdx = raw.indexOf("#");
+    if (hashIdx >= 0) raw = raw.slice(0, hashIdx).trim();
+  }
+  // Strip surrounding quotes if present.
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    raw = raw.slice(1, -1);
+  }
+  return raw;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/typescript/helper/tests/integration/helper.test.ts
+++ b/typescript/helper/tests/integration/helper.test.ts
@@ -1,0 +1,35 @@
+// Mirrors rust/helper/tests/helper_tests.rs.
+//
+// Assumes:
+//  - suibase is installed at ~/suibase
+//  - localnet is started
+//  - 'demo' package is published to localnet
+//
+// In CI/CD this is set up by scripts/tests/030_rust_cargo_tests/__test_common.sh
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { Helper } from "../../src/index.js";
+
+test("integration: isInstalled", () => {
+  const sbh = new Helper();
+  assert.equal(sbh.isInstalled(), true);
+});
+
+test("integration: localnet workdir resolves to 'localnet'", () => {
+  const sbh = new Helper();
+  assert.equal(sbh.isInstalled(), true);
+  sbh.selectWorkdir("localnet");
+  assert.equal(sbh.workdir(), "localnet");
+});
+
+test("integration: demo package_id is a valid 66-char hex string", () => {
+  const sbh = new Helper();
+  assert.equal(sbh.isInstalled(), true);
+  sbh.selectWorkdir("localnet");
+  assert.equal(sbh.workdir(), "localnet");
+  const id = sbh.packageId("demo");
+  assert.ok(id.startsWith("0x"), `expected 0x-prefixed id, got ${id}`);
+  assert.equal(id.length, 66, `expected length 66, got ${id.length}`);
+});

--- a/typescript/helper/tests/unit/fixtures.ts
+++ b/typescript/helper/tests/unit/fixtures.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface FixtureWorkdirOptions {
+  name: string;
+  active?: boolean;
+  withDemo?: boolean;
+  withKeystore?: boolean;
+  withState?: boolean;
+  withClientYaml?: boolean;
+}
+
+export interface Fixture {
+  root: string;
+  workdirsPath: string;
+  workdirPath(name: string): string;
+  cleanup(): void;
+}
+
+export function makeFixture(workdirs: FixtureWorkdirOptions[] = []): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "suibase-test-"));
+  const workdirsPath = join(root, "workdirs");
+  mkdirSync(workdirsPath, { recursive: true });
+
+  let activeTarget: string | undefined;
+
+  for (const wd of workdirs) {
+    const wdPath = join(workdirsPath, wd.name);
+    mkdirSync(wdPath, { recursive: true });
+
+    if (wd.withState !== false) {
+      const statePath = join(wdPath, ".state");
+      mkdirSync(statePath, { recursive: true });
+      writeFileSync(join(statePath, "name"), `${wd.name}\n`);
+      writeFileSync(
+        join(statePath, "dns"),
+        JSON.stringify({
+          known: {
+            "sb-1-ed25519": {
+              address:
+                "0x0fc530455ee4132b761ed82dab732990cb7af73e69cd6e719a2a5badeaed105b",
+            },
+            "sb-2-ed25519": {
+              address:
+                "0x1cf34ae2e006fbfa9cee6ae4703b1a6c4ef627ab22e92e226bc6975521d0d705",
+            },
+          },
+        }),
+      );
+      writeFileSync(
+        join(statePath, "links"),
+        JSON.stringify({
+          selection: { primary: 0, secondary: 0, n_links: 1 },
+          links: [
+            {
+              id: 0,
+              alias: wd.name,
+              rpc: `http://localhost:9000/${wd.name}`,
+              ws: `ws://localhost:9000/${wd.name}`,
+            },
+          ],
+        }),
+      );
+    }
+
+    if (wd.withKeystore) {
+      const cfgPath = join(wdPath, "config");
+      mkdirSync(cfgPath, { recursive: true });
+      writeFileSync(join(cfgPath, "sui.keystore"), "[]");
+    }
+
+    if (wd.withClientYaml) {
+      const cfgPath = join(wdPath, "config");
+      mkdirSync(cfgPath, { recursive: true });
+      writeFileSync(
+        join(cfgPath, "client.yaml"),
+        `---
+keystore:
+  File: ${cfgPath}/sui.keystore
+envs:
+  - alias: ${wd.name}
+    rpc: "http://localhost:9000"
+active_env: ${wd.name}
+active_address: "0xabcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890"
+`,
+      );
+    }
+
+    if (wd.withDemo) {
+      // Build a demo package publication snapshot at
+      // published-data/demo/<uuid>/<timestamp>/{package-id.json,created-objects.json}
+      // with a "most-recent" symlink that resolves to it.
+      const pkgRoot = join(wdPath, "published-data", "demo");
+      const uuid = "U123";
+      const ts = "T456";
+      const target = join(pkgRoot, uuid, ts);
+      mkdirSync(target, { recursive: true });
+
+      const packageId =
+        "0xfeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface";
+      writeFileSync(
+        join(target, "package-id.json"),
+        `["${packageId}"]\n`,
+      );
+      writeFileSync(
+        join(target, "created-objects.json"),
+        JSON.stringify([
+          {
+            type: `${packageId}::Counter::Counter`,
+            objectId:
+              "0x1111111111111111111111111111111111111111111111111111111111111111",
+          },
+          {
+            type: `${packageId}::Counter::Counter`,
+            objectId:
+              "0x2222222222222222222222222222222222222222222222222222222222222222",
+          },
+          {
+            type: `${packageId}::Other::Thing`,
+            objectId:
+              "0x3333333333333333333333333333333333333333333333333333333333333333",
+          },
+        ]),
+      );
+      // most-recent symlink: relative for portability
+      symlinkSync(`${uuid}/${ts}`, join(pkgRoot, "most-recent"));
+    }
+
+    if (wd.active) {
+      activeTarget = wdPath;
+    }
+  }
+
+  if (activeTarget) {
+    symlinkSync(activeTarget, join(workdirsPath, "active"));
+  }
+
+  return {
+    root,
+    workdirsPath,
+    workdirPath: (name: string) => join(workdirsPath, name),
+    cleanup() {
+      try {
+        rmSync(root, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    },
+  };
+}

--- a/typescript/helper/tests/unit/helper.test.ts
+++ b/typescript/helper/tests/unit/helper.test.ts
@@ -1,0 +1,243 @@
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+import { Helper, SuibaseError } from "../../src/index.js";
+import { makeFixture, type Fixture } from "./fixtures.js";
+
+describe("Helper.isInstalled()", () => {
+  test("returns true when root + workdirs/ exist", () => {
+    const fx = makeFixture([]);
+    try {
+      const sbh = new Helper({ rootPath: fx.root });
+      assert.equal(sbh.isInstalled(), true);
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("returns false when root does not exist", () => {
+    const sbh = new Helper({ rootPath: "/nonexistent/path/suibase" });
+    assert.equal(sbh.isInstalled(), false);
+  });
+});
+
+describe("Helper.selectWorkdir()", () => {
+  let fx: Fixture;
+  before(() => {
+    fx = makeFixture([
+      { name: "localnet", withDemo: true, withKeystore: true, withClientYaml: true, active: true },
+      { name: "devnet" },
+    ]);
+  });
+  after(() => fx.cleanup());
+
+  test("selects a real workdir by name", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.equal(sbh.workdir(), "localnet");
+  });
+
+  test("'active' resolves to the workdir behind the symlink", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("active");
+    // The fixture set localnet as active.
+    assert.equal(sbh.workdir(), "localnet");
+  });
+
+  test("empty name throws", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    assert.throws(() => sbh.selectWorkdir(""), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "WorkdirNameEmpty",
+    );
+  });
+
+  test("nonexistent name throws", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    assert.throws(() => sbh.selectWorkdir("ghost"), (e: unknown) =>
+      e instanceof SuibaseError &&
+        (e.code === "WorkdirNotExists" || e.code === "WorkdirAccessError"),
+    );
+  });
+
+  test("workdir() before selectWorkdir() throws", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    assert.throws(() => sbh.workdir(), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "WorkdirNotSelected",
+    );
+  });
+});
+
+describe("Helper.packageId() / packageObjectId()", () => {
+  let fx: Fixture;
+  before(() => {
+    fx = makeFixture([{ name: "localnet", withDemo: true }]);
+  });
+  after(() => fx.cleanup());
+
+  test("returns the published package id (0x... 66 chars)", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    const id = sbh.packageId("demo");
+    assert.ok(id.startsWith("0x"));
+    assert.equal(id.length, 66);
+  });
+
+  test("missing package throws PublishedData* error", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.throws(() => sbh.packageId("nopkg"), (e: unknown) =>
+      e instanceof SuibaseError && e.code.startsWith("PublishedData"),
+    );
+  });
+
+  test("empty package name throws", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.throws(() => sbh.packageId(""), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "PackageNameEmpty",
+    );
+  });
+
+  test("without selectWorkdir throws WorkdirNotSelected", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    assert.throws(() => sbh.packageId("demo"), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "WorkdirNotSelected",
+    );
+  });
+});
+
+describe("Helper.publishedNewObjects()", () => {
+  let fx: Fixture;
+  before(() => {
+    fx = makeFixture([{ name: "localnet", withDemo: true }]);
+  });
+  after(() => fx.cleanup());
+
+  test("returns matching object IDs for module::type", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    const ids = sbh.publishedNewObjects("demo::Counter::Counter");
+    assert.equal(ids.length, 2);
+    for (const id of ids) {
+      assert.ok(id.startsWith("0x"));
+      assert.equal(id.length, 66);
+    }
+  });
+
+  test("returns empty array when no objects match", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    const ids = sbh.publishedNewObjects("demo::Nope::Missing");
+    assert.deepEqual(ids, []);
+  });
+
+  test("invalid format throws", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.throws(() => sbh.publishedNewObjects("just_one_part"), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "ObjectTypeInvalidFormat",
+    );
+    assert.throws(() => sbh.publishedNewObjects("demo::Counter::Counter::Extra"), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "ObjectTypeInvalidFormat",
+    );
+  });
+
+  test("empty field throws", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.throws(() => sbh.publishedNewObjects("demo:: ::Counter"), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "ObjectTypeMissingField",
+    );
+  });
+});
+
+describe("Helper.clientAddress()", () => {
+  let fx: Fixture;
+  before(() => {
+    fx = makeFixture([{ name: "localnet", withClientYaml: true }]);
+  });
+  after(() => fx.cleanup());
+
+  test("returns 'active' address from client.yaml", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    const addr = sbh.clientAddress("active");
+    assert.equal(
+      addr,
+      "0xabcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890",
+    );
+  });
+
+  test("returns named address from .state/dns", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    const addr = sbh.clientAddress("sb-1-ed25519");
+    assert.equal(
+      addr,
+      "0x0fc530455ee4132b761ed82dab732990cb7af73e69cd6e719a2a5badeaed105b",
+    );
+  });
+
+  test("empty name throws", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.throws(() => sbh.clientAddress(""), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "AddressNameEmpty",
+    );
+  });
+
+  test("unknown name throws AddressNameNotFound", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.throws(() => sbh.clientAddress("sb-99-bogus"), (e: unknown) =>
+      e instanceof SuibaseError && e.code === "AddressNameNotFound",
+    );
+  });
+});
+
+describe("Helper.rpcUrl() / wsUrl()", () => {
+  let fx: Fixture;
+  before(() => {
+    fx = makeFixture([{ name: "localnet" }]);
+  });
+  after(() => fx.cleanup());
+
+  test("rpcUrl reads from .state/links primary link", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.equal(sbh.rpcUrl(), "http://localhost:9000/localnet");
+  });
+
+  test("wsUrl reads from .state/links primary link", () => {
+    const sbh = new Helper({ rootPath: fx.root });
+    sbh.selectWorkdir("localnet");
+    assert.equal(sbh.wsUrl(), "ws://localhost:9000/localnet");
+  });
+});
+
+describe("Helper.keystorePathname()", () => {
+  test("returns path when keystore exists", () => {
+    const fx = makeFixture([{ name: "localnet", withKeystore: true }]);
+    try {
+      const sbh = new Helper({ rootPath: fx.root });
+      sbh.selectWorkdir("localnet");
+      const p = sbh.keystorePathname();
+      assert.ok(p.endsWith("config/sui.keystore"));
+    } finally {
+      fx.cleanup();
+    }
+  });
+
+  test("throws when keystore missing", () => {
+    const fx = makeFixture([{ name: "localnet" }]);
+    try {
+      const sbh = new Helper({ rootPath: fx.root });
+      sbh.selectWorkdir("localnet");
+      assert.throws(() => sbh.keystorePathname(), (e: unknown) =>
+        e instanceof SuibaseError && e.code === "SuibaseKeystoreNotExists",
+      );
+    } finally {
+      fx.cleanup();
+    }
+  });
+});

--- a/typescript/helper/tsconfig.json
+++ b/typescript/helper/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary

- Makes the gRPC upstream-selection in `proxy_server.rs` respect `selectable: false` — bringing it in line with JSON-RPC.
- Refactors the inline selection logic into `select_grpc_upstreams`, a pure helper unit-tested with 6 cases including the exact mis-route from the field investigation.
- Verified TDD red→green: removing the new check fails the targeted tests with the production diagnostic.

## Why

JSON-RPC dispatch (`InputPort::update_selection_vectors` and `get_best_target_servers`) already excludes `!is_selectable` servers entirely — they're invisible to the selector. gRPC dispatch had a fallback loop that did the opposite: after exhausting selectable + healthy targets via `best`, it iterated **all** target_servers and added any gRPC-capable one, regardless of `selectable`.

That asymmetry has real consequences in mixed configs (e.g., a `selectable: false` real backend alongside `selectable: true` test mocks). When the selectable servers fail their gRPC-capability check (or all become unhealthy), the dispatcher silently routed production gRPC traffic to the non-selectable backend that the operator explicitly marked as "do not route here". The exact symptom in this investigation: production gRPC calls to the proxy got served by daemon-internal mock servers, which returned placeholder data (chain_id `"00000000"`) that sui CLI then cached into client.yaml, breaking subsequent operations.

After this fix: gRPC behaves like JSON-RPC. `selectable: false` means **never** picked, even as last resort. A config with no selectable gRPC-capable server returns `NO_SERVER_AVAILABLE` fast — same semantics on both protocols.

## What changed in the code

`src/proxy_server.rs`:
- Extract the inline gRPC upstream selection (was 555-577, inside `grpc_dispatch`) into a free function `select_grpc_upstreams(best, target_servers, is_grpc_capable)`.
- Add `ts.is_selectable() &&` to the fallback loop predicate.
- Add `#[cfg(test)] mod tests` with 6 unit tests covering the selection behavior.

## TDD verification

1. Added unit tests against the new helper — all 6 pass.
2. Reverted just the `ts.is_selectable() &&` check (keeping the refactor) and re-ran tests:
   - `non_selectable_server_is_never_picked_even_as_fallback` — FAIL: returns `[(0, "http://localnet:9000")]` instead of empty (the production mis-route).
   - `mixed_selectable_non_selectable_only_returns_selectable` — FAIL: returns 3 entries instead of 2 (the non-selectable backend leaks in).
3. Restored the check; all 6 tests pass again.

## Breaking-behavior surface

If a `suibase.yaml` config lists ONLY non-selectable upstreams (e.g. `selectable: false` on the sole real backend), gRPC will now fail fast with NO_SERVER_AVAILABLE instead of silently routing. This is intentional and consistent with how JSON-RPC already behaves on the same config. Operators relying on the previous lenient gRPC behavior should flip the upstream's `selectable` to `true`.

## Resume context (for a future session)

- This is one of three PRs from the 2026-05-22 "publish-via-proxy fails" investigation. Companions:
  1. **Streaming buffering** in `proxy_grpc.rs` — held as uncommitted diff on `dev` (stash: `WIP: streaming fix + daemon test infra (for code review)`). Adds regression test `tests/proxy_grpc_streaming_test.rs`.
  2. **Move.toml `localnet_proxy` env entry** — PR #127 (`add-localnet-proxy-env-to-movetoml`).
  3. **THIS PR** — proxy gRPC respect `selectable`.
- All three are independent and necessary for `localnet publish` to work end-to-end through the proxy.
- Full root-cause notes in `~/.claude/projects/-home-olet-suibase/memory/project_publish_proxy_complete_fix.md` (Claude persistent memory).
- The known follow-up not addressed here: localnet chain_id is non-deterministic across `regen`. That affects Move.toml staleness but is independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)