### PR TITLE
dev/start-daemon: bootstrap missing binary via sb_app_install

### DIFF
--- a/scripts/dev/start-daemon
+++ b/scripts/dev/start-daemon
@@ -18,4 +18,11 @@ exit_if_deps_missing
 
 cli_mutex_lock "suibase_daemon"
 
-start_suibase_daemon
+# Bootstrap the binary if missing — `start_suibase_daemon_as_needed`
+# routes through `sb_app_install` which downloads the precompiled from
+# chainmovers/sui-binaries (gated against leapfrogging the local source
+# version). When the binary is already present, the function is a thin
+# no-op then defers to `start_suibase_daemon` exactly like before, so
+# this preserves behavior for developers who manage their own binary.
+# Force-build is still available via `dev/update-daemon`.
+start_suibase_daemon_as_needed


### PR DESCRIPTION
## Summary

Fixes the CI failure on release-tests / main-nightly-tests workflows that aborts at \`dev/start-daemon\` with:

\`\`\`
Error: suibase-daemon binary not found (build failed?)
Error: Process completed with exit code 1.
\`\`\`

One-line change in \`scripts/dev/start-daemon\`: call \`start_suibase_daemon_as_needed\` (which routes through \`sb_app_install\` → precompiled download) instead of \`start_suibase_daemon\` (which only starts an existing binary).

## Why this broke

The workflows added in [a587a562](https://github.com/ChainMovers/suibase/commit/a587a562) (main-nightly) and [bc69dd95](https://github.com/ChainMovers/suibase/commit/bc69dd95) (release-tests, mirroring main-nightly) verify the precompiled binary by:

\`\`\`yaml
"$HOME/suibase/install"
"$HOME/suibase/scripts/dev/start-daemon"
\`\`\`

The inline comment claims:

> # start-daemon calls start_suibase_daemon_as_needed → sb_app_install.

But \`scripts/dev/start-daemon\` actually calls \`start_suibase_daemon\` (no \`_as_needed\`), which only does:

\`\`\`bash
if [ ! -f "$SUIBASE_DAEMON_BIN" ]; then
   setup_error "$SUIBASE_DAEMON_NAME binary not found (build failed?)"
fi
\`\`\`

In CI \`install\` only sets symlinks — it doesn't download the daemon binary. So \`start-daemon\` exited before reaching the version-match assertion that those workflows are designed to enforce.

## What the fix does

Replace one line in \`scripts/dev/start-daemon\`:

\`\`\`diff
- start_suibase_daemon
+ start_suibase_daemon_as_needed
\`\`\`

The wrapper:
- when binary exists: trivial no-op, falls through to \`start_suibase_daemon\` exactly like before
- when binary missing: routes through \`sb_app_install\` → precompiled download from chainmovers/sui-binaries (the [cc0df120](https://github.com/ChainMovers/suibase/commit/cc0df120) gate still prevents leapfrogging local source)

\`dev/update-daemon\` is unchanged; force-rebuild-from-source is still available there.

## Verified locally

Host had the daemon running (pid 1245906, ~28 min uptime, binary present). Ran \`bash -c 'set -e; ~/suibase/scripts/dev/start-daemon; echo "exit=\$?"'\` — output was empty (silent no-op) with \`exit=0\`. Daemon kept running, proxy still responsive on \`sui_getChainIdentifier\`. So the dev-user path behavior the user emphasized "took a long time to work" is preserved.

The CI bootstrap path (binary missing → install) is exercised by the same \`start_suibase_daemon_as_needed\` that \`dev/update-daemon\` already uses with \`--force-build\`; this PR just uses it without the force-build flag, leaning on \`sb_app_install\`'s native precompiled-first behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)