### PR TITLE
Promote pre-staging to staging (manual: deliver status-fix)

### DIFF
--- a/.github/workflows/staging-promote.yml
+++ b/.github/workflows/staging-promote.yml
@@ -116,6 +116,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          pre_sha=$(git rev-parse origin/pre-staging)
+
+          # GitHub's branch protection requires `enforce-pipeline-order` to
+          # pass on the PR's head commit. That check is provided by the
+          # pr-gate.yml workflow on `pull_request` events. HOWEVER, PRs
+          # opened by GITHUB_TOKEN (this workflow's default token) do NOT
+          # trigger `pull_request` workflows — it's a deliberate GitHub
+          # security feature to prevent infinite workflow loops.
+          #
+          # Since we ARE the legitimate, structurally-correct head
+          # (head_ref == pre-staging, base == staging — exactly the
+          # constraint pr-gate enforces), set the status directly via the
+          # Statuses API. Branch protection accepts a commit status with
+          # the same context name as a satisfied required check.
+          gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$pre_sha" \
+            -f state=success \
+            -f context=enforce-pipeline-order \
+            -f description="head_ref=pre-staging into base=staging is allowed (set by staging-promote.yml)" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            >/dev/null
+
           # Avoid duplicates if a previous cron tick already opened the PR.
           existing=$(gh pr list --base staging --head pre-staging --state open --json number --jq '.[0].number')
           if [ -n "$existing" ]; then

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -183,6 +183,23 @@ jobs:
             exit 0
           fi
 
+          # GitHub's branch protection requires `enforce-pipeline-order`
+          # to pass on the PR's head commit. That check is provided by
+          # pr-gate.yml on `pull_request` events — but PRs opened by
+          # GITHUB_TOKEN (this workflow's default token) do NOT trigger
+          # `pull_request` workflows (security feature against infinite
+          # workflow loops). Since we ARE the legitimate, structurally-
+          # correct head (head_ref == staging into base == main, which
+          # is exactly what pr-gate enforces), set the status directly
+          # via the Statuses API. Branch protection accepts a status
+          # with the same context name as a satisfied required check.
+          gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$staging_sha" \
+            -f state=success \
+            -f context=enforce-pipeline-order \
+            -f description="head_ref=staging into base=main is allowed (set by staging.yml)" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            >/dev/null
+
           existing=$(gh pr list --base main --head staging --state open --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
             echo "PR #$existing already open staging → main; enabling auto-merge."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Discord chat](https://img.shields.io/discord/1038616996062953554.svg?logo=discord&style=flat-square)](https://discord.gg/Erb6SwsVbH) [![Active Development](https://img.shields.io/badge/Maintenance%20Level-Actively%20Developed-brightgreen.svg)](https://gist.github.com/cheerfulstoic/d107229326a01ff0f333a1d3476e068d)
 
-[![release](https://github.com/ChainMovers/suibase/actions/workflows/main-nightly-tests.yml/badge.svg)](https://github.com/ChainMovers/suibase/actions/workflows/main-nightly-tests.yml) [![nightly](https://github.com/ChainMovers/suibase/actions/workflows/dev-nightly-tests.yml/badge.svg)](https://github.com/ChainMovers/suibase/actions/workflows/dev-nightly-tests.yml)
+[![release](https://github.com/ChainMovers/suibase/actions/workflows/main-nightly-tests.yml/badge.svg)](https://github.com/ChainMovers/suibase/actions/workflows/main-nightly-tests.yml) [![staging](https://github.com/ChainMovers/suibase/actions/workflows/staging.yml/badge.svg?branch=staging)](https://github.com/ChainMovers/suibase/actions/workflows/staging.yml) [![nightly](https://github.com/ChainMovers/suibase/actions/workflows/dev-nightly-tests.yml/badge.svg)](https://github.com/ChainMovers/suibase/actions/workflows/dev-nightly-tests.yml)
 
 Streamlines development and testing of your Sui network apps.
 

--- a/scripts/dev/apply-branch-protection
+++ b/scripts/dev/apply-branch-protection
@@ -36,17 +36,22 @@ apply_protection() {
   #   * allow_force_pushes=false / allow_deletions=false (safety).
   #   * required_linear_history=false (staging-promote opens merge
   #     commits; don't break it).
+  # Use -F (typed) rather than -f (string) so the strict/contexts
+  # values land in the JSON as boolean/array correctly. Some older
+  # gh CLI versions only accept arrays via -F here.
   gh api -X PUT "repos/$REPO/branches/$branch/protection" \
     -H "Accept: application/vnd.github+json" \
-    -f required_status_checks[strict]=false \
-    -f "required_status_checks[contexts][]=$CHECK_NAME" \
-    -f enforce_admins=false \
-    -f required_pull_request_reviews=null \
-    -f restrictions=null \
-    -f allow_force_pushes=false \
-    -f allow_deletions=false \
-    -f required_linear_history=false \
-    -f allow_fork_syncing=false \
+    -F enforce_admins=false \
+    -F required_pull_request_reviews=null \
+    -F restrictions=null \
+    -F allow_force_pushes=false \
+    -F allow_deletions=false \
+    -F required_linear_history=false \
+    -F lock_branch=false \
+    -F allow_fork_syncing=false \
+    -F required_conversation_resolution=false \
+    -F "required_status_checks[strict]=false" \
+    -F "required_status_checks[contexts][]=$CHECK_NAME" \
     >/dev/null
 
   echo "  ✓ $branch protected (PR Gate required, no human review, no force-push, no delete)"

--- a/scripts/dev/merge
+++ b/scripts/dev/merge
@@ -54,29 +54,30 @@ fi
 # shellcheck source=./sync
 source "$HOME/suibase/scripts/dev/sync"
 
-# Switch to pre-staging.
-echo "Switching to pre-staging branch"
+# Promote dev → pre-staging via auto-merge PR.
+#
+# Branch protection on pre-staging requires PRs (no direct push), so we
+# open one and immediately enable auto-merge. With matching tips this is
+# essentially instant; with the pr-gate check it's also instant
+# (head_ref == dev satisfies the gate). Required: `gh` CLI authenticated.
 git fetch origin pre-staging
-git checkout pre-staging
-git pull --ff-only origin pre-staging
-
-# Find the common ancestor of dev and pre-staging.
-merge_base=$(git merge-base dev pre-staging)
 
 # Check if there are any changes from dev that are not in pre-staging.
-if git diff --quiet "$merge_base" dev; then
+if git merge-base --is-ancestor dev origin/pre-staging; then
   echo "No changes to merge from dev to pre-staging."
-else
-  # Fast-forward only — pre-staging is downstream of dev, never ahead.
-  if git merge --ff-only dev; then
-    echo "Merged dev into pre-staging."
-    git push origin pre-staging
-    # Stay on dev for the next iteration.
-    git checkout dev
-  else
-    echo "Fast-forward merge failed. pre-staging has diverged from dev,"
-    echo "which should not happen under the release pipeline. Run"
-    echo "'~/suibase/scripts/dev/sync' to reconcile."
-    exit 1
-  fi
+  exit 0
 fi
+
+# Reuse an open PR if one exists; otherwise open one.
+existing=$(gh pr list --base pre-staging --head dev --state open --json number --jq '.[0].number')
+if [ -z "$existing" ]; then
+  version=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' rust/suibase/Cargo.toml 2>/dev/null)
+  title="Promote dev to pre-staging"
+  [ -n "$version" ] && title="$title (suibase-daemon v$version)"
+  gh pr create --base pre-staging --head dev \
+    --title "$title" \
+    --body "Auto-opened by \`scripts/dev/merge\`. The pipeline (pre-staging.yml → cron → staging.yml) carries it through to main. See CONTRIBUTING.md."
+  existing=$(gh pr list --base pre-staging --head dev --state open --json number --jq '.[0].number')
+fi
+echo "Auto-merging PR #$existing dev → pre-staging..."
+gh pr merge "$existing" --auto --merge


### PR DESCRIPTION
Manually opened to bypass cron's strict-ancestor check while delivering the pr-gate status-set fix. The divergence between staging and pre-staging is structural to --merge mode and will be addressed in a follow-up commit.