### PR TITLE
Promote pre-staging to staging (manual: deliver perms-fix + portability)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Node 22 — pnpm@latest started importing `node:sqlite` in late
+          # May 2026 which is only available on Node 22.5+; Node 20 fails
+          # with ERR_UNKNOWN_BUILTIN_MODULE.
+          node-version: 22
           cache: pnpm
           cache-dependency-path: "docs/pnpm-lock.yaml"
 

--- a/.github/workflows/main-nightly-tests.yml
+++ b/.github/workflows/main-nightly-tests.yml
@@ -109,8 +109,10 @@ jobs:
           "$HOME/suibase/install"
           "$HOME/suibase/scripts/dev/start-daemon"
 
-          src_version=$(grep "^version" "$GITHUB_WORKSPACE/rust/suibase/Cargo.toml" \
-            | sed -e 's/version[[:space:]]*=[[:space:]]*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)".*/\1/')
+          # awk for portability — the previous `sed ... \+` regex is GNU-only;
+          # BSD sed on macOS-latest leaves the line unchanged.
+          src_version=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' \
+            "$GITHUB_WORKSPACE/rust/suibase/Cargo.toml")
           bin_version=$("$HOME/suibase/workdirs/common/bin/suibase-daemon" --version 2>/dev/null \
             | awk '{print $2}')
 

--- a/.github/workflows/pre-staging.yml
+++ b/.github/workflows/pre-staging.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Read daemon version from Cargo.toml
         id: ver
         run: |
-          version=$(grep "^version" rust/suibase/Cargo.toml \
-            | sed -e 's/version[[:space:]]*=[[:space:]]*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)".*/\1/')
+          # awk for portability — the GNU sed `\+` regex used previously
+          # is not supported by BSD sed and silently no-ops on macOS.
+          version=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' \
+            rust/suibase/Cargo.toml)
           if [ -z "$version" ]; then
             echo "::error::Could not parse daemon version from rust/suibase/Cargo.toml"
             exit 1

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -58,8 +58,10 @@ jobs:
           "$HOME/suibase/install"
           "$HOME/suibase/scripts/dev/start-daemon"
 
-          src_version=$(grep "^version" "$GITHUB_WORKSPACE/rust/suibase/Cargo.toml" \
-            | sed -e 's/version[[:space:]]*=[[:space:]]*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)".*/\1/')
+          # awk for portability — the previous `sed ... \+` regex is GNU-only;
+          # BSD sed on macOS-latest leaves the line unchanged.
+          src_version=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' \
+            "$GITHUB_WORKSPACE/rust/suibase/Cargo.toml")
           bin_version=$("$HOME/suibase/workdirs/common/bin/suibase-daemon" --version 2>/dev/null \
             | awk '{print $2}')
 

--- a/.github/workflows/staging-promote.yml
+++ b/.github/workflows/staging-promote.yml
@@ -33,6 +33,12 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # `statuses: write` lets this workflow set the
+      # `enforce-pipeline-order` commit status directly on the PR's
+      # head — needed because pr-gate.yml's pull_request workflow
+      # does not fire on PRs opened by GITHUB_TOKEN (GitHub security
+      # feature against infinite loops).
+      statuses: write
     steps:
       - name: Checkout pre-staging
         uses: actions/checkout@v4

--- a/.github/workflows/staging-promote.yml
+++ b/.github/workflows/staging-promote.yml
@@ -43,8 +43,10 @@ jobs:
       - name: Read daemon version from pre-staging
         id: ver
         run: |
-          version=$(grep "^version" rust/suibase/Cargo.toml \
-            | sed -e 's/version[[:space:]]*=[[:space:]]*"\([0-9]\+\.[0-9]\+\.[0-9]\+\)".*/\1/')
+          # awk for portability — the GNU sed `\+` regex used previously
+          # is not supported by BSD sed and silently no-ops on macOS.
+          version=$(awk -F'"' '/^version[[:space:]]*=/{print $2; exit}' \
+            rust/suibase/Cargo.toml)
           if [ -z "$version" ]; then
             echo "::error::Could not parse daemon version from pre-staging's rust/suibase/Cargo.toml"
             exit 1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -162,9 +162,14 @@ jobs:
       # `contents: write` is needed by `gh pr merge --auto` to enable
       # auto-merge on a branch-protected base (main). `pull-requests:
       # write` alone is enough to OPEN the PR but not to flip the
-      # auto-merge bit when main is protected.
+      # auto-merge bit when main is protected. `statuses: write` is
+      # required to set the `enforce-pipeline-order` commit status
+      # (the workflow can't satisfy the required check via the normal
+      # pull_request workflow because PRs opened by GITHUB_TOKEN don't
+      # trigger pull_request events — security feature).
       contents: write
       pull-requests: write
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Manual: main's staging-promote.yml still lacks statuses:write perms (couldn't ride through previous cycle). This delivers awk version-parse + statuses:write perms to staging; the resulting staging.yml run there will be the first fully autonomous staging→main.