### PR TITLE
ci(deploy-docs): pin pnpm version instead of "latest"

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,7 +42,14 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: "latest"
+          # Pinned, not "latest": pnpm/action-setup's self-update step
+          # (switching from its bundled version to whatever "latest"
+          # resolves to on the registry) started crashing with "Cannot
+          # use 'in' operator to search for 'integrity' in undefined"
+          # — an upstream pnpm bug, unrelated to this repo. Pinning to
+          # the bundled version it installs cleanly skips that
+          # self-update path entirely.
+          version: "11.7.0"
           run_install: true
 
       - name: Copy pnpm dependency files


### PR DESCRIPTION
## Summary
- `pnpm/action-setup`'s self-update step is currently crashing on every run (`Cannot use 'in' operator to search for 'integrity' in undefined`) when switching from its bundled pnpm version to whatever `"latest"` resolves to on the registry — an upstream pnpm bug, unrelated to this repo's content
- This is currently blocking `Deploy Vuepress` on every push to `main`, including the icon-fix hotfix that just landed
- Pins to `11.7.0`, the version confirmed working in the failed run's own logs (it installs cleanly, then crashes trying to self-update)

## Test plan
- [x] Confirmed reproducible via `gh run rerun` on the failed `Deploy Vuepress` run — same crash both times
- [ ] Verify `Deploy Vuepress` succeeds once this reaches `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)